### PR TITLE
T-205 Implement analytics and reporting page for coordinator and tutor views

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { CoordinatorShell } from "../components/coordinator-shell";
 import { TutorShell } from "../components/tutor-shell";
 import { useAppContext } from "../context/app-context";
@@ -69,14 +69,11 @@ function AnalyticsContent() {
     return workshops.filter((workshop) => workshop.tutorName === currentUserName);
   }, [viewRole, workshops, currentUserName]);
 
-  useEffect(() => {
-    if (
-      selectedWorkshopId !== "all" &&
-      !visibleWorkshops.some((workshop) => workshop.id === selectedWorkshopId)
-    ) {
-      setSelectedWorkshopId("all");
-    }
-  }, [selectedWorkshopId, visibleWorkshops]);
+  const effectiveWorkshopId =
+    selectedWorkshopId === "all" ||
+    visibleWorkshops.some((workshop) => workshop.id === selectedWorkshopId)
+      ? selectedWorkshopId
+      : "all";
 
   const allRows = useMemo<AnalyticsRow[]>(() => {
     const rows = visibleWorkshops.flatMap((workshop) => {
@@ -87,7 +84,7 @@ function AnalyticsContent() {
           .map((week) => sessionMarks[week.id]?.[student.studentId])
           .filter((score): score is Score => score !== undefined);
 
-        const totalScore = recordedScores.reduce((sum, score) => sum + score, 0);
+        const totalScore = recordedScores.reduce<number>((sum, score) => sum + score, 0);
         const averageScore = recordedScores.length > 0 ? totalScore / recordedScores.length : null;
         const gradePercentage =
           totalParticipationPoints > 0
@@ -138,11 +135,11 @@ function AnalyticsContent() {
   ]);
 
   const filteredRows = useMemo(() => {
-    if (selectedWorkshopId === "all") {
+    if (effectiveWorkshopId === "all") {
       return allRows;
     }
-    return allRows.filter((row) => row.workshopId === selectedWorkshopId);
-  }, [allRows, selectedWorkshopId]);
+    return allRows.filter((row) => row.workshopId === effectiveWorkshopId);
+  }, [allRows, effectiveWorkshopId]);
 
   const totalRecordedMarks = filteredRows.reduce((sum, row) => sum + row.marksRecorded, 0);
   const totalRecordedScore = filteredRows.reduce((sum, row) => sum + row.totalScore, 0);
@@ -150,17 +147,17 @@ function AnalyticsContent() {
   const atRiskRows = filteredRows.filter((row) => row.isAtRisk);
   const totalStudents = filteredRows.length;
   const totalWorkshops =
-    selectedWorkshopId === "all" ? visibleWorkshops.length : totalStudents > 0 ? 1 : 0;
+    effectiveWorkshopId === "all" ? visibleWorkshops.length : totalStudents > 0 ? 1 : 0;
 
   const showWorkshopFilter = viewRole === "coordinator" || visibleWorkshops.length > 1;
-  const showWorkshopColumn = viewRole === "coordinator" || selectedWorkshopId === "all";
-
+  const showWorkshopColumn = viewRole === "coordinator" || effectiveWorkshopId === "all";
+  
   const handleExportCsv = () => {
-    const workshopLabel =
-      selectedWorkshopId === "all"
+      const workshopLabel =
+      effectiveWorkshopId === "all"
         ? "all-workshops"
         : toFileSafeSegment(
-            visibleWorkshops.find((workshop) => workshop.id === selectedWorkshopId)?.name ??
+            visibleWorkshops.find((workshop) => workshop.id === effectiveWorkshopId)?.name ??
               "selected-workshop",
           );
 
@@ -321,7 +318,7 @@ function AnalyticsContent() {
 
             {showWorkshopFilter && (
               <select
-                value={selectedWorkshopId}
+                value={effectiveWorkshopId}
                 onChange={(e) => setSelectedWorkshopId(e.target.value)}
                 style={{
                   background: "#ffffff",

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -27,6 +27,20 @@ function getDisplayName(firstName: string, lastName: string, preferredName?: str
   return `${firstName} ${lastName}`.trim();
 }
 
+function escapeCsvValue(value: string | number | null | undefined) {
+  const text = value === null || value === undefined ? "" : String(value);
+
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+
+  return text;
+}
+
+function toFileSafeSegment(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
 function AnalyticsContent() {
   const {
     viewRole,
@@ -141,6 +155,58 @@ function AnalyticsContent() {
   const showWorkshopFilter = viewRole === "coordinator" || visibleWorkshops.length > 1;
   const showWorkshopColumn = viewRole === "coordinator" || selectedWorkshopId === "all";
 
+  const handleExportCsv = () => {
+    const workshopLabel =
+      selectedWorkshopId === "all"
+        ? "all-workshops"
+        : toFileSafeSegment(
+            visibleWorkshops.find((workshop) => workshop.id === selectedWorkshopId)?.name ??
+              "selected-workshop",
+          );
+
+    const roleLabel = viewRole === "coordinator" ? "coordinator" : "tutor";
+
+    const headers = [
+      "Student ID",
+      "Student Name",
+      ...(showWorkshopColumn ? ["Workshop"] : []),
+      "Email",
+      "Marks Recorded",
+      "Enabled Weeks",
+      "Avg Score",
+      "Grade (%)",
+      "Status",
+    ];
+
+    const rows = filteredRows.map((row) => [
+      row.studentId,
+      row.studentName,
+      ...(showWorkshopColumn ? [row.workshopName] : []),
+      row.email,
+      row.marksRecorded,
+      enabledWeeks.length,
+      row.averageScore === null ? "" : row.averageScore.toFixed(2),
+      row.gradePercentage.toFixed(1),
+      row.isAtRisk ? "At Risk" : "On Track",
+    ]);
+
+    const csvContent = [headers, ...rows]
+      .map((row) => row.map((cell) => escapeCsvValue(cell)).join(","))
+      .join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+
+    link.href = url;
+    link.setAttribute("download", `analytics-${roleLabel}-${workshopLabel}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+  };
+
   const metricGridClassName =
     viewRole === "coordinator"
       ? "real-page-panel dashboard-metric-grid"
@@ -148,9 +214,37 @@ function AnalyticsContent() {
 
   return (
     <>
-      <header className="prototype-header">
-        <h1>Analytics & Reporting</h1>
-        <p>Student participation insights and statistics</p>
+      <header
+        className="prototype-header"
+        style={{
+          alignItems: "flex-start",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "16px",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <h1>Analytics & Reporting</h1>
+          <p>Student participation insights and statistics</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleExportCsv}
+          style={{
+            background: "#4f46e5",
+            border: "none",
+            borderRadius: "12px",
+            color: "#ffffff",
+            cursor: "pointer",
+            fontSize: "14px",
+            fontWeight: 700,
+            padding: "12px 18px",
+          }}
+        >
+          Export CSV
+        </button>
       </header>
 
       <section className={metricGridClassName}>

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,23 +1,449 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { CoordinatorShell } from "../components/coordinator-shell";
 import { TutorShell } from "../components/tutor-shell";
 import { useAppContext } from "../context/app-context";
+import type { Score } from "../context/app-context";
+
+type AnalyticsRow = {
+  studentId: string;
+  studentName: string;
+  email: string;
+  workshopId: string;
+  workshopName: string;
+  marksRecorded: number;
+  totalScore: number;
+  averageScore: number | null;
+  gradePercentage: number;
+  isAtRisk: boolean;
+};
+
+function getDisplayName(firstName: string, lastName: string, preferredName?: string) {
+  const preferred = preferredName?.trim();
+  if (preferred) {
+    return `${preferred} ${lastName}`.trim();
+  }
+  return `${firstName} ${lastName}`.trim();
+}
 
 function AnalyticsContent() {
+  const {
+    viewRole,
+    workshops,
+    workshopStudents,
+    configWeeks,
+    sessionMarks,
+    maxWeeklyScore,
+    totalAssessmentWeighting,
+    currentUserName,
+  } = useAppContext();
+
+  const [selectedWorkshopId, setSelectedWorkshopId] = useState("all");
+
+  const enabledWeeks = useMemo(() => {
+    return configWeeks.filter((week) => week.enabled);
+  }, [configWeeks]);
+
+  const totalParticipationPoints = enabledWeeks.length * maxWeeklyScore;
+
+  const visibleWorkshops = useMemo(() => {
+    if (viewRole === "coordinator") {
+      return workshops;
+    }
+
+    return workshops.filter((workshop) => workshop.tutorName === currentUserName);
+  }, [viewRole, workshops, currentUserName]);
+
+  useEffect(() => {
+    if (
+      selectedWorkshopId !== "all" &&
+      !visibleWorkshops.some((workshop) => workshop.id === selectedWorkshopId)
+    ) {
+      setSelectedWorkshopId("all");
+    }
+  }, [selectedWorkshopId, visibleWorkshops]);
+
+  const allRows = useMemo<AnalyticsRow[]>(() => {
+    const rows = visibleWorkshops.flatMap((workshop) => {
+      const students = workshopStudents[workshop.id] ?? [];
+
+      return students.map((student) => {
+        const recordedScores = enabledWeeks
+          .map((week) => sessionMarks[week.id]?.[student.studentId])
+          .filter((score): score is Score => score !== undefined);
+
+        const totalScore = recordedScores.reduce((sum, score) => sum + score, 0);
+        const averageScore = recordedScores.length > 0 ? totalScore / recordedScores.length : null;
+        const gradePercentage =
+          totalParticipationPoints > 0
+            ? (totalScore / totalParticipationPoints) * totalAssessmentWeighting
+            : 0;
+
+        const isAtRisk =
+          enabledWeeks.length > 0 &&
+          (recordedScores.length === 0 || (averageScore !== null && averageScore < 1.5));
+
+        return {
+          studentId: student.studentId,
+          studentName: getDisplayName(
+            student.firstName,
+            student.lastName,
+            student.preferredName,
+          ),
+          email: student.email,
+          workshopId: workshop.id,
+          workshopName: workshop.name,
+          marksRecorded: recordedScores.length,
+          totalScore,
+          averageScore,
+          gradePercentage,
+          isAtRisk,
+        };
+      });
+    });
+
+    return [...rows].sort((a, b) => {
+      if (a.isAtRisk !== b.isAtRisk) {
+        return a.isAtRisk ? -1 : 1;
+      }
+
+      if (a.gradePercentage !== b.gradePercentage) {
+        return a.gradePercentage - b.gradePercentage;
+      }
+
+      return a.studentName.localeCompare(b.studentName);
+    });
+  }, [
+    visibleWorkshops,
+    workshopStudents,
+    enabledWeeks,
+    sessionMarks,
+    totalParticipationPoints,
+    totalAssessmentWeighting,
+  ]);
+
+  const filteredRows = useMemo(() => {
+    if (selectedWorkshopId === "all") {
+      return allRows;
+    }
+    return allRows.filter((row) => row.workshopId === selectedWorkshopId);
+  }, [allRows, selectedWorkshopId]);
+
+  const totalRecordedMarks = filteredRows.reduce((sum, row) => sum + row.marksRecorded, 0);
+  const totalRecordedScore = filteredRows.reduce((sum, row) => sum + row.totalScore, 0);
+  const averageScore = totalRecordedMarks > 0 ? totalRecordedScore / totalRecordedMarks : 0;
+  const atRiskRows = filteredRows.filter((row) => row.isAtRisk);
+  const totalStudents = filteredRows.length;
+  const totalWorkshops =
+    selectedWorkshopId === "all" ? visibleWorkshops.length : totalStudents > 0 ? 1 : 0;
+
+  const showWorkshopFilter = viewRole === "coordinator" || visibleWorkshops.length > 1;
+  const showWorkshopColumn = viewRole === "coordinator" || selectedWorkshopId === "all";
+
+  const metricGridClassName =
+    viewRole === "coordinator"
+      ? "real-page-panel dashboard-metric-grid"
+      : "real-page-panel dashboard-metric-grid dashboard-metric-grid--three";
+
   return (
     <>
       <header className="prototype-header">
-        <h1>Analytics</h1>
-        <p>Participation performance insights will appear here.</p>
+        <h1>Analytics & Reporting</h1>
+        <p>Student participation insights and statistics</p>
       </header>
+
+      <section className={metricGridClassName}>
+        <article className="prototype-card dashboard-metric-card">
+          <p className="dashboard-metric-label">Avg Score</p>
+          <p className="dashboard-metric-value">{averageScore.toFixed(2)}</p>
+        </article>
+
+        <article className="prototype-card dashboard-metric-card">
+          <p className="dashboard-metric-label">Total Students</p>
+          <p className="dashboard-metric-value">{totalStudents}</p>
+        </article>
+
+        {viewRole === "coordinator" && (
+          <article className="prototype-card dashboard-metric-card">
+            <p className="dashboard-metric-label">Total Workshops</p>
+            <p className="dashboard-metric-value">{totalWorkshops}</p>
+          </article>
+        )}
+
+        <article className="prototype-card dashboard-metric-card">
+          <p className="dashboard-metric-label">At-Risk Students</p>
+          <p className="dashboard-metric-value">{atRiskRows.length}</p>
+        </article>
+      </section>
 
       <section className="real-page-panel">
         <article className="prototype-card dashboard-list-card">
-          <h2 className="section-card-title">Coming Soon</h2>
-          <p className="dashboard-empty">
-            This view is under active development. Use Dashboard and Mark Participation for current workflows.
-          </p>
+          <h2 className="section-card-title">At-Risk Students</h2>
+
+          {enabledWeeks.length === 0 ? (
+            <p className="dashboard-empty">
+              No participation weeks are enabled yet. Configure weeks in Settings first.
+            </p>
+          ) : atRiskRows.length === 0 ? (
+            <p className="dashboard-empty">
+              No at-risk students identified for the current filter.
+            </p>
+          ) : (
+            <div className="dashboard-list">
+              {atRiskRows.slice(0, 8).map((row) => (
+                <div key={row.studentId} className="dashboard-list-row">
+                  <div>
+                    <p className="dashboard-list-title">{row.studentName}</p>
+                    <p className="dashboard-list-sub">
+                      {row.workshopName} • {row.studentId} • {row.gradePercentage.toFixed(1)}%
+                    </p>
+                  </div>
+                  <span className="dashboard-badge">
+                    {row.marksRecorded === 0 ? "No marks yet" : "At Risk"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </article>
+      </section>
+
+      <section className="real-page-panel">
+        <article className="prototype-card dashboard-list-card">
+          <div
+            style={{
+              alignItems: "center",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "12px",
+              justifyContent: "space-between",
+              marginBottom: "16px",
+            }}
+          >
+            <h2 className="section-card-title" style={{ margin: 0 }}>
+              All Students - Detailed Breakdown
+            </h2>
+
+            {showWorkshopFilter && (
+              <select
+                value={selectedWorkshopId}
+                onChange={(e) => setSelectedWorkshopId(e.target.value)}
+                style={{
+                  background: "#ffffff",
+                  border: "1px solid #d7dfeb",
+                  borderRadius: "10px",
+                  color: "#172033",
+                  fontSize: "14px",
+                  minWidth: "200px",
+                  padding: "10px 12px",
+                }}
+              >
+                <option value="all">All Workshops</option>
+                {visibleWorkshops.map((workshop) => (
+                  <option key={workshop.id} value={workshop.id}>
+                    {workshop.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {filteredRows.length === 0 ? (
+            <p className="dashboard-empty">
+              No student analytics data is available yet for this view.
+            </p>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table
+                style={{
+                  borderCollapse: "collapse",
+                  minWidth: showWorkshopColumn ? "860px" : "720px",
+                  width: "100%",
+                }}
+              >
+                <thead>
+                  <tr>
+                    <th
+                      style={{
+                        borderBottom: "1px solid #e5eaf3",
+                        color: "#56657c",
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        padding: "12px 10px",
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Student
+                    </th>
+
+                    {showWorkshopColumn && (
+                      <th
+                        style={{
+                          borderBottom: "1px solid #e5eaf3",
+                          color: "#56657c",
+                          fontSize: "13px",
+                          fontWeight: 700,
+                          padding: "12px 10px",
+                          textAlign: "left",
+                          textTransform: "uppercase",
+                        }}
+                      >
+                        Workshop
+                      </th>
+                    )}
+
+                    <th
+                      style={{
+                        borderBottom: "1px solid #e5eaf3",
+                        color: "#56657c",
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        padding: "12px 10px",
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Marks Recorded
+                    </th>
+                    <th
+                      style={{
+                        borderBottom: "1px solid #e5eaf3",
+                        color: "#56657c",
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        padding: "12px 10px",
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Avg Score
+                    </th>
+                    <th
+                      style={{
+                        borderBottom: "1px solid #e5eaf3",
+                        color: "#56657c",
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        padding: "12px 10px",
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Grade
+                    </th>
+                    <th
+                      style={{
+                        borderBottom: "1px solid #e5eaf3",
+                        color: "#56657c",
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        padding: "12px 10px",
+                        textAlign: "left",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      Status
+                    </th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  {filteredRows.map((row) => (
+                    <tr key={`${row.workshopId}-${row.studentId}`}>
+                      <td
+                        style={{
+                          borderBottom: "1px solid #eef2f7",
+                          padding: "14px 10px",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        <div style={{ color: "#172033", fontSize: "15px", fontWeight: 600 }}>
+                          {row.studentName}
+                        </div>
+                        <div style={{ color: "#6b7a90", fontSize: "13px", marginTop: "2px" }}>
+                          {row.studentId}
+                        </div>
+                      </td>
+
+                      {showWorkshopColumn && (
+                        <td
+                          style={{
+                            borderBottom: "1px solid #eef2f7",
+                            color: "#172033",
+                            fontSize: "14px",
+                            padding: "14px 10px",
+                            verticalAlign: "top",
+                          }}
+                        >
+                          {row.workshopName}
+                        </td>
+                      )}
+
+                      <td
+                        style={{
+                          borderBottom: "1px solid #eef2f7",
+                          color: "#172033",
+                          fontSize: "14px",
+                          padding: "14px 10px",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        {row.marksRecorded} / {enabledWeeks.length}
+                      </td>
+
+                      <td
+                        style={{
+                          borderBottom: "1px solid #eef2f7",
+                          color: "#172033",
+                          fontSize: "14px",
+                          padding: "14px 10px",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        {row.averageScore === null ? "—" : row.averageScore.toFixed(2)}
+                      </td>
+
+                      <td
+                        style={{
+                          borderBottom: "1px solid #eef2f7",
+                          color: "#172033",
+                          fontSize: "14px",
+                          padding: "14px 10px",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        {row.gradePercentage.toFixed(1)}%
+                      </td>
+
+                      <td
+                        style={{
+                          borderBottom: "1px solid #eef2f7",
+                          padding: "14px 10px",
+                          verticalAlign: "top",
+                        }}
+                      >
+                        <span
+                          style={{
+                            background: row.isAtRisk ? "#fff4d6" : "#eaf8ef",
+                            borderRadius: "999px",
+                            color: row.isAtRisk ? "#9a6700" : "#1f7a44",
+                            display: "inline-block",
+                            fontSize: "12px",
+                            fontWeight: 700,
+                            padding: "6px 10px",
+                          }}
+                        >
+                          {row.isAtRisk ? "At Risk" : "On Track"}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </article>
       </section>
     </>


### PR DESCRIPTION
## Summary
This PR replaces the placeholder Analytics page with a working frontend analytics and reporting view for both Coordinator and Tutor roles.

The page now uses existing context data instead of the previous "Coming Soon" placeholder.

## What this PR does
- implements the Analytics & Reporting page
- supports both Coordinator and Tutor views
- renders analytics using current frontend context data
- adds summary metric cards
- adds an At-Risk Students section
- adds an All Students detailed breakdown table
- adds workshop filtering where applicable
- applies role-based visibility:
  - Coordinator can view all visible workshops
  - Tutor can only view assigned workshop(s)

## Included analytics metrics
### Coordinator view
- Avg Score
- Total Students
- Total Workshops
- At-Risk Students

### Tutor view
- Avg Score
- Total Students
- At-Risk Students

## Data sources used
This implementation uses existing frontend state from context:
- workshops
- workshopStudents
- configWeeks
- sessionMarks
- maxWeeklyScore
- totalAssessmentWeighting

## At-risk logic
A student is currently flagged as at risk when:
- participation weeks are enabled but the student has no recorded marks, or
- the student's average score is below 1.5

This is intended as an MVP frontend rule and can be refined later if needed.

## Notes
- no backend integration was added in this PR
- no export functionality was added in this PR
- this PR focuses on replacing the placeholder with a usable analytics MVP aligned with the current Figma direction

## Tested locally:
- enabled participation weeks in Settings
- created a workshop
- uploaded a CSV roster successfully
- verified analytics renders summary cards, at-risk section, and detailed breakdown
- verified analytics is no longer a placeholder page

Closes #32