### PR TITLE
Integrate frontend with existing participation APIs

### DIFF
--- a/app/components/review-session.tsx
+++ b/app/components/review-session.tsx
@@ -25,10 +25,12 @@ type ReviewSessionProps = {
  * current scores (from context). Allows inline score correction before
  * final submission.
  */
-export function ReviewSession({ students, weekId, weekLabel }: ReviewSessionProps) {
+export function ReviewSession({ students, weekId }: ReviewSessionProps) {
   const router = useRouter();
-  const { sessionMarks, setMark } = useAppContext();
+  const { sessionMarks, setMark, submitWeekMarks } = useAppContext();
   const [showMilestone, setShowMilestone] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const weekMarks = sessionMarks[weekId] ?? {};
 
@@ -40,16 +42,27 @@ export function ReviewSession({ students, weekId, weekLabel }: ReviewSessionProp
   // Sort students alphabetically by name (matches Figma)
   const sorted = [...students].sort((a, b) => a.name.localeCompare(b.name));
 
-  function handleSubmit() {
+  async function handleSubmit() {
     if (!canSubmit) return;
 
-    // Show Week 6 milestone popup before navigating away
-    if (weekId === "week-6") {
-      setShowMilestone(true);
-      return;
-    }
+    setIsSubmitting(true);
+    setSubmitError(null);
 
-    router.push("/marking");
+    try {
+      await submitWeekMarks(weekId);
+
+      // Show Week 6 milestone popup before navigating away
+      if (weekId === "week-6") {
+        setShowMilestone(true);
+        return;
+      }
+
+      router.push("/marking");
+    } catch {
+      setSubmitError("Marks are saved locally, but backend submission did not complete.");
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   function dismissMilestone() {
@@ -122,6 +135,12 @@ export function ReviewSession({ students, weekId, weekLabel }: ReviewSessionProp
       {unmarkedCount > 0 && (
         <p className="review-warning" role="alert">
           {unmarkedCount} student{unmarkedCount === 1 ? "" : "s"} still need a score before submission.
+        </p>
+      )}
+
+      {submitError && (
+        <p className="review-warning" role="alert">
+          {submitError}
         </p>
       )}
 
@@ -208,11 +227,11 @@ export function ReviewSession({ students, weekId, weekLabel }: ReviewSessionProp
           type="button"
           className="marking-nav-btn marking-nav-btn--primary"
           onClick={handleSubmit}
-          disabled={!canSubmit}
-          aria-disabled={!canSubmit}
+          disabled={!canSubmit || isSubmitting}
+          aria-disabled={!canSubmit || isSubmitting}
           style={{ padding: "13px 28px" }}
         >
-          Submit &amp; Complete
+          {isSubmitting ? "Submitting..." : "Submit & Complete"}
         </button>
         <button
           type="button"

--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CoordinatorShell } from "../components/coordinator-shell";
 import { useAppContext } from "../context/app-context";
+import { replaceEnabledWeeks, updateCurrentSystemConfig } from "../lib/services/participation";
 
 export default function ConfigPage() {
   const {
@@ -12,9 +13,12 @@ export default function ConfigPage() {
     setMaxWeeklyScore,
     totalAssessmentWeighting,
     setTotalAssessmentWeighting,
+    currentUserId,
   } = useAppContext();
 
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
   const [activeTab, setActiveTab] = useState<"unit" | "students">("unit");
 
   const selectedWeeks = weeks.filter((w) => w.enabled);
@@ -22,6 +26,7 @@ export default function ConfigPage() {
 
   const toggleWeek = (weekId: string) => {
     setSaved(false);
+    setSaveError(null);
     setWeeks(weeks.map((w) => (w.id === weekId && !w.locked ? { ...w, enabled: !w.enabled } : w)));
   };
 
@@ -36,6 +41,7 @@ export default function ConfigPage() {
 
   const toggleWeek6Lock = () => {
     setSaved(false);
+    setSaveError(null);
     if (week6AllLocked) {
       setWeeks(weeks.map((w) => (week6Ids.includes(w.id) ? { ...w, locked: false } : w)));
     } else {
@@ -46,11 +52,35 @@ export default function ConfigPage() {
 
   const toggleWeek12Lock = () => {
     setSaved(false);
+    setSaveError(null);
     if (week12AllLocked) {
       setWeeks(weeks.map((w) => (week12Ids.includes(w.id) ? { ...w, locked: false } : w)));
     } else {
       // Locking should never force week selection; preserve existing enabled states.
       setWeeks(weeks.map((w) => (week12Ids.includes(w.id) ? { ...w, locked: true } : w)));
+    }
+  };
+
+  const saveConfiguration = async () => {
+    setIsSaving(true);
+    setSaved(false);
+    setSaveError(null);
+
+    try {
+      await replaceEnabledWeeks(selectedWeeks.map((week) => week.weekNumber));
+      await updateCurrentSystemConfig({
+        max_weekly_score: maxWeeklyScore,
+        total_participation_points: totalAssessmentWeighting,
+        is_configured: selectedWeeks.length > 0,
+        week6_lock_enabled: week6AllLocked,
+        week12_lock_enabled: week12AllLocked,
+        updated_by_user_id: currentUserId,
+      });
+      setSaved(true);
+    } catch {
+      setSaveError("Saved locally. Backend configuration could not be updated from this frontend session.");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -65,10 +95,11 @@ export default function ConfigPage() {
         <div className="flex flex-col items-end gap-1">
           <button
             type="button"
-            onClick={() => setSaved(true)}
+            onClick={saveConfiguration}
+            disabled={isSaving}
             className="rounded-full bg-[var(--navy)] px-5 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-90"
           >
-            Save configuration
+            {isSaving ? "Saving..." : "Save configuration"}
           </button>
           <p className="text-xs text-[var(--ink-soft)]">Changes are auto-saved</p>
         </div>
@@ -92,6 +123,9 @@ export default function ConfigPage() {
 
       {saved && activeTab === "unit" && (
         <div className="config-save-banner">Configuration saved successfully.</div>
+      )}
+      {saveError && activeTab === "unit" && (
+        <div className="config-save-banner">{saveError}</div>
       )}
 
       {activeTab === "unit" && (
@@ -162,6 +196,7 @@ export default function ConfigPage() {
                   value={maxWeeklyScore}
                   onChange={(e) => {
                     setSaved(false);
+                    setSaveError(null);
                     const v = Number(e.target.value);
                     if (!Number.isNaN(v) && v >= 1 && v <= 3) setMaxWeeklyScore(v);
                   }}
@@ -181,6 +216,7 @@ export default function ConfigPage() {
                   value={totalAssessmentWeighting}
                   onChange={(e) => {
                     setSaved(false);
+                    setSaveError(null);
                     const v = Number(e.target.value);
                     if (!Number.isNaN(v))
                       setTotalAssessmentWeighting(Math.min(100, Math.max(0, v)));

--- a/app/context/app-context.tsx
+++ b/app/context/app-context.tsx
@@ -10,6 +10,19 @@ import {
   setStoredToken,
   getStoredToken,
 } from "../lib/services/auth";
+import {
+  createBackendWorkshop,
+  deleteBackendWorkshop,
+  getBackendUsers,
+  getBackendWorkshops,
+  getCurrentSystemConfig,
+  getEnabledWeeks,
+  getWorkshopWeekMarks,
+  updateBackendWorkshop,
+  createMark as createBackendMark,
+  updateMark as updateBackendMark,
+} from "../lib/services/participation";
+import { ApiError } from "../interface/apiTypes";
 
 export type { Score };
 export type ViewRole = "coordinator" | "tutor";
@@ -28,6 +41,7 @@ export type WorkshopRecord = {
   name: string;
   tutorName: string | null;
   tutorEmail: string | null;
+  tutorUserId?: string | null;
 };
 
 // weekId → studentId → Score
@@ -37,6 +51,7 @@ interface AppContextValue {
   isAuthLoading: boolean;
   isAuthenticated: boolean;
   authRole: AuthRole | null;
+  currentUserId: string | null;
   currentUserName: string;
   currentUserEmail: string;
   loginWithCredentials: (email: string, password: string) => Promise<void>;
@@ -68,6 +83,7 @@ interface AppContextValue {
   setMark: (weekId: string, studentId: string, score: Score) => void;
   clearWeekMarks: (weekId: string) => void;
   getWeekMarkedCount: (weekId: string) => number;
+  submitWeekMarks: (weekId: string) => Promise<void>;
 }
 
 const AppContext = createContext<AppContextValue | null>(null);
@@ -77,6 +93,7 @@ const STORAGE_KEY = "pms-app-config";
 type PersistedState = Partial<{
   isAuthenticated: boolean;
   authRole: AuthRole;
+  currentUserId: string | null;
   currentUserName: string;
   currentUserEmail: string;
   viewRole: ViewRole;
@@ -93,6 +110,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [isAuthLoading, setIsAuthLoading] = useState(() => Boolean(getStoredToken()));
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authRole, setAuthRole] = useState<AuthRole | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [currentUserName, setCurrentUserName] = useState("");
   const [currentUserEmail, setCurrentUserEmail] = useState("");
   const [viewRole, setViewRoleState] = useState<ViewRole>("tutor");
@@ -104,6 +122,12 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const [sessionMarks, setSessionMarks] = useState<SessionMarks>({});
   const [activeWorkshopId, setActiveWorkshopId] = useState<string | null>(null);
   const hasHydratedFromStorage = useRef(false);
+  const hasHydratedFromApi = useRef(false);
+
+  const isBackendWorkshopId = (id: string) => /^\d+$/.test(id);
+
+  const mapBackendRole = (role: string): AuthRole =>
+    role === "UC" ? "coordinator" : "tutor";
 
   function applyPersistedState(saved: PersistedState) {
     if (Array.isArray(saved.workshops)) {
@@ -125,6 +149,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
     if (typeof saved.activeWorkshopId === "string" || saved.activeWorkshopId === null) {
       setActiveWorkshopId(saved.activeWorkshopId ?? null);
     }
+    if (typeof saved.currentUserId === "string" || saved.currentUserId === null) {
+      setCurrentUserId(saved.currentUserId ?? null);
+    }
   }
 
   // Hydrate persisted state only after mount to avoid SSR/client HTML mismatches.
@@ -136,7 +163,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
         return;
       }
       const saved = JSON.parse(raw) as PersistedState;
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       applyPersistedState(saved);
     } catch {
       // ignore read/parse issues and keep defaults
@@ -154,6 +180,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     getMe()
       .then((user) => {
         setAuthRole(user.role);
+        setCurrentUserId(String(user.id));
         setCurrentUserName(user.name);
         setCurrentUserEmail(user.email);
         setViewRoleState(user.role);
@@ -163,12 +190,73 @@ export function AppProvider({ children }: { children: ReactNode }) {
         clearStoredToken();
         setIsAuthenticated(false);
         setAuthRole(null);
+        setCurrentUserId(null);
         setCurrentUserName("");
         setCurrentUserEmail("");
       })
       .finally(() => {
         setIsAuthLoading(false);
       });
+  }, []);
+
+  // Pull read-only API-backed configuration/workshops into the frontend workflow when available.
+  useEffect(() => {
+    if (hasHydratedFromApi.current) return;
+    hasHydratedFromApi.current = true;
+
+    async function hydrateFromApi() {
+      try {
+        const [backendUsers, backendWorkshops, enabledWeeks, systemConfig] = await Promise.all([
+          getBackendUsers().catch(() => []),
+          getBackendWorkshops().catch(() => []),
+          getEnabledWeeks().catch(() => []),
+          getCurrentSystemConfig().catch(() => null),
+        ]);
+
+        if (backendWorkshops.length > 0) {
+          const usersById = new Map(backendUsers.map((user) => [user.user_id, user]));
+          setWorkshops((existing) => {
+            const localOnly = existing.filter((workshop) => !isBackendWorkshopId(workshop.id));
+            const apiWorkshops = backendWorkshops
+              .filter((workshop) => workshop.is_active)
+              .map((workshop) => {
+                const tutor = workshop.tutor_user_id
+                  ? usersById.get(workshop.tutor_user_id)
+                  : undefined;
+
+                return {
+                  id: String(workshop.workshop_id),
+                  name: workshop.workshop_name,
+                  tutorName: tutor?.display_name ?? null,
+                  tutorEmail: tutor?.email ?? null,
+                  tutorUserId: workshop.tutor_user_id,
+                } satisfies WorkshopRecord;
+              });
+
+            return [...apiWorkshops, ...localOnly];
+          });
+        }
+
+        if (enabledWeeks.length > 0) {
+          const enabledWeekNumbers = new Set(enabledWeeks.map((week) => week.week_number));
+          setConfigWeeks((existing) =>
+            existing.map((week) => ({
+              ...week,
+              enabled: enabledWeekNumbers.has(week.weekNumber),
+            })),
+          );
+        }
+
+        if (systemConfig) {
+          setMaxWeeklyScore(systemConfig.max_weekly_score);
+          setTotalAssessmentWeighting(systemConfig.total_participation_points);
+        }
+      } catch {
+        // Keep local/offline workflow available when the backend is not running or configured.
+      }
+    }
+
+    void hydrateFromApi();
   }, []);
 
   // Persist on every state change.
@@ -180,6 +268,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         JSON.stringify({
           isAuthenticated,
           authRole,
+          currentUserId,
           currentUserName,
           currentUserEmail,
           viewRole,
@@ -198,6 +287,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [
     isAuthenticated,
     authRole,
+    currentUserId,
     currentUserName,
     currentUserEmail,
     viewRole,
@@ -214,6 +304,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     const response = await loginApi({ email, password });
     setStoredToken(response.access_token);
     setAuthRole(response.user.role);
+    setCurrentUserId(String(response.user.id));
     setCurrentUserName(response.user.name ?? email);
     setCurrentUserEmail(response.user.email ?? email);
     setViewRoleState(response.user.role);
@@ -229,9 +320,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
     // TODO(T-304): remove dev test login path once backend auth is fully integrated in all environments.
     const defaults =
       role === "coordinator"
-        ? { name: "Dr. Joachim Strand", email: "joachim.strand@uwa.edu.au" }
-        : { name: "Alex Chen", email: "alex.chen@uwa.edu.au" };
+        ? { name: "Dr. Joachim Strand", email: "joachim.strand@uwa.edu.au", id: null }
+        : { name: "Alex Chen", email: "alex.chen@uwa.edu.au", id: null };
     setAuthRole(role);
+    setCurrentUserId(defaults.id);
     setCurrentUserName(defaults.name);
     setCurrentUserEmail(defaults.email);
     setViewRoleState(role);
@@ -242,6 +334,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     clearStoredToken();
     setIsAuthenticated(false);
     setAuthRole(null);
+    setCurrentUserId(null);
     setCurrentUserName("");
     setCurrentUserEmail("");
     setViewRoleState("tutor");
@@ -262,6 +355,42 @@ export function AppProvider({ children }: { children: ReactNode }) {
         tutorEmail: tutorEmail?.trim() || null,
       },
     ]);
+
+    void (async () => {
+      try {
+        const users = tutorEmail
+          ? await getBackendUsers().catch(() => [])
+          : [];
+        const tutor = users.find((user) => user.email.toLowerCase() === tutorEmail?.trim().toLowerCase());
+        const backendWorkshop = await createBackendWorkshop({
+          workshop_name: trimmed,
+          tutor_user_id: tutor?.user_id ?? null,
+          is_active: true,
+        });
+        setWorkshops((prev) =>
+          prev.map((workshop) =>
+            workshop.id === id
+              ? {
+                  ...workshop,
+                  id: String(backendWorkshop.workshop_id),
+                  tutorUserId: backendWorkshop.tutor_user_id,
+                }
+              : workshop,
+          ),
+        );
+        setWorkshopStudents((prev) => {
+          if (!prev[id]) return prev;
+          const next = { ...prev, [String(backendWorkshop.workshop_id)]: prev[id] };
+          delete next[id];
+          return next;
+        });
+        setActiveWorkshopId((current) =>
+          current === id ? String(backendWorkshop.workshop_id) : current,
+        );
+      } catch {
+        // The local workflow remains usable if the API is offline or the tutor is not in backend users yet.
+      }
+    })();
     return id;
   }
 
@@ -271,6 +400,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
     const removedStudentIds = new Set((workshopStudents[workshopId] ?? []).map((student) => student.studentId));
 
     setWorkshops((prev) => prev.filter((item) => item.id !== workshopId));
+
+    if (isBackendWorkshopId(workshopId)) {
+      void deleteBackendWorkshop(Number(workshopId)).catch(() => undefined);
+    }
 
     setWorkshopStudents((prev) => {
       const next = { ...prev };
@@ -316,6 +449,16 @@ export function AppProvider({ children }: { children: ReactNode }) {
           : workshop,
       ),
     );
+
+    if (isBackendWorkshopId(workshopId)) {
+      void (async () => {
+        const users = tutorEmail ? await getBackendUsers().catch(() => []) : [];
+        const tutor = users.find((user) => user.email.toLowerCase() === tutorEmail?.trim().toLowerCase());
+        await updateBackendWorkshop(Number(workshopId), {
+          tutor_user_id: tutor?.user_id ?? null,
+        });
+      })().catch(() => undefined);
+    }
   }
 
   function assignCurrentUserAsTutor(workshopId: string) {
@@ -331,6 +474,20 @@ export function AppProvider({ children }: { children: ReactNode }) {
           : workshop,
       ),
     );
+
+    if (isBackendWorkshopId(workshopId)) {
+      void (async () => {
+        const users = await getBackendUsers().catch(() => []);
+        const currentUser = users.find(
+          (user) => user.email.toLowerCase() === currentUserEmail.toLowerCase(),
+        );
+        if (!currentUser) return;
+        setCurrentUserId(currentUser.user_id);
+        await updateBackendWorkshop(Number(workshopId), {
+          tutor_user_id: currentUser.user_id,
+        });
+      })().catch(() => undefined);
+    }
   }
 
   function upsertWorkshopStudentsFromCsv(workshopId: string, students: WorkshopStudent[]) {
@@ -343,6 +500,73 @@ export function AppProvider({ children }: { children: ReactNode }) {
       ...prev,
       [weekId]: { ...(prev[weekId] ?? {}), [studentId]: score },
     }));
+  }
+
+  async function submitWeekMarks(weekId: string): Promise<void> {
+    if (!activeWorkshopId || !isBackendWorkshopId(activeWorkshopId)) return;
+
+    const week = configWeeks.find((item) => item.id === weekId);
+    if (!week) return;
+
+    const workshopId = Number(activeWorkshopId);
+    const markedStudents = Object.entries(sessionMarks[weekId] ?? {});
+    if (markedStudents.length === 0) return;
+
+    let markerUserId = currentUserId;
+    if (!markerUserId && currentUserEmail) {
+      const users = await getBackendUsers();
+      const currentUser = users.find(
+        (user) => user.email.toLowerCase() === currentUserEmail.toLowerCase(),
+      );
+      markerUserId = currentUser?.user_id ?? null;
+      if (markerUserId) {
+        setCurrentUserId(markerUserId);
+        setAuthRole(mapBackendRole(currentUser?.role ?? "tutor"));
+      }
+    }
+
+    if (!markerUserId) {
+      throw new ApiError("Cannot submit marks until the current tutor exists in backend users.", 400);
+    }
+
+    let existingMarks = await getWorkshopWeekMarks(workshopId, week.weekNumber).catch((error) => {
+      if (error instanceof ApiError && error.status === 404) return [];
+      throw error;
+    });
+    const existingByStudentId = new Map(existingMarks.map((mark) => [mark.student_id, mark]));
+
+    for (const [studentId, score] of markedStudents) {
+      const existing = existingByStudentId.get(studentId);
+      if (existing) {
+        const updated = await updateBackendMark(existing.mark_id, {
+          score,
+          marked_by_user_id: markerUserId,
+        });
+        existingByStudentId.set(studentId, updated);
+        continue;
+      }
+
+      try {
+        const created = await createBackendMark({
+          student_id: studentId,
+          workshop_id: workshopId,
+          week_number: week.weekNumber,
+          score,
+          marked_by_user_id: markerUserId,
+        });
+        existingByStudentId.set(studentId, created);
+      } catch (error) {
+        if (!(error instanceof ApiError) || error.status !== 400) throw error;
+        existingMarks = await getWorkshopWeekMarks(workshopId, week.weekNumber);
+        const duplicate = existingMarks.find((mark) => mark.student_id === studentId);
+        if (!duplicate) throw error;
+        const updated = await updateBackendMark(duplicate.mark_id, {
+          score,
+          marked_by_user_id: markerUserId,
+        });
+        existingByStudentId.set(studentId, updated);
+      }
+    }
   }
 
   function clearWeekMarks(weekId: string) {
@@ -363,6 +587,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         isAuthLoading,
         isAuthenticated,
         authRole,
+        currentUserId,
         currentUserName,
         currentUserEmail,
         loginWithCredentials,
@@ -376,6 +601,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         totalAssessmentWeighting, setTotalAssessmentWeighting,
         activeWorkshopId, setActiveWorkshopId,
         sessionMarks, setMark, clearWeekMarks, getWeekMarkedCount,
+        submitWeekMarks,
       }}
     >
       {children}

--- a/app/interface/apiTypes.ts
+++ b/app/interface/apiTypes.ts
@@ -38,3 +38,69 @@ export type AuthTokenResponse = {
   token_type: string;
   user: AuthUserDto;
 };
+
+export type BackendUserRole = "UC" | "tutor";
+
+export type UserDto = {
+  user_id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  preferred_name: string | null;
+  display_name: string;
+  role: BackendUserRole;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string | null;
+};
+
+export type WorkshopDto = {
+  workshop_id: number;
+  workshop_name: string;
+  tutor_user_id: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string | null;
+};
+
+export type StudentDto = {
+  student_id: string;
+  first_name: string;
+  last_name: string;
+  preferred_name: string | null;
+  email: string;
+  image_url: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string | null;
+};
+
+export type EnabledWeekDto = {
+  week_number: number;
+  created_at: string;
+};
+
+export type SystemConfigDto = {
+  config_id: number;
+  coordinator_user_id: string;
+  max_weekly_score: number;
+  total_participation_points: number;
+  is_configured: boolean;
+  week6_lock_enabled: boolean;
+  week6_locked_at: string | null;
+  week12_lock_enabled: boolean;
+  week12_locked_at: string | null;
+  updated_by_user_id: string | null;
+  updated_at: string;
+};
+
+export type MarkDto = {
+  mark_id: number;
+  student_id: string;
+  workshop_id: number;
+  week_number: number;
+  score: number;
+  marked_by_user_id: string;
+  marked_at: string;
+  updated_at: string | null;
+};

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,4 +1,5 @@
 export { apiClient, apiRequest } from "./axios-instance";
 export * from "./services/auth";
 export * from "./services/health";
+export * from "./services/participation";
 export * from "./services/user";

--- a/app/lib/services/participation.ts
+++ b/app/lib/services/participation.ts
@@ -1,0 +1,107 @@
+import { apiRequest } from "../axios-instance";
+import type {
+  EnabledWeekDto,
+  MarkDto,
+  StudentDto,
+  SystemConfigDto,
+  UserDto,
+  WorkshopDto,
+} from "../../interface/apiTypes";
+
+export type CreateWorkshopPayload = {
+  workshop_name: string;
+  tutor_user_id?: string | null;
+  is_active?: boolean;
+};
+
+export type UpdateWorkshopPayload = Partial<CreateWorkshopPayload>;
+
+export type CreateMarkPayload = {
+  student_id: string;
+  workshop_id: number;
+  week_number: number;
+  score: number;
+  marked_by_user_id: string;
+};
+
+export type UpdateMarkPayload = Partial<CreateMarkPayload>;
+
+export function getBackendUsers(): Promise<UserDto[]> {
+  return apiRequest<UserDto[]>({ method: "GET", url: "/users/" });
+}
+
+export function getBackendWorkshops(): Promise<WorkshopDto[]> {
+  return apiRequest<WorkshopDto[]>({ method: "GET", url: "/workshops/" });
+}
+
+export function createBackendWorkshop(payload: CreateWorkshopPayload): Promise<WorkshopDto> {
+  return apiRequest<WorkshopDto>({ method: "POST", url: "/workshops/", data: payload });
+}
+
+export function updateBackendWorkshop(
+  workshopId: number,
+  payload: UpdateWorkshopPayload,
+): Promise<WorkshopDto> {
+  return apiRequest<WorkshopDto>({
+    method: "PATCH",
+    url: `/workshops/${workshopId}`,
+    data: payload,
+  });
+}
+
+export function deleteBackendWorkshop(workshopId: number): Promise<void> {
+  return apiRequest<void>({ method: "DELETE", url: `/workshops/${workshopId}` });
+}
+
+export function getBackendStudents(): Promise<StudentDto[]> {
+  return apiRequest<StudentDto[]>({ method: "GET", url: "/students/" });
+}
+
+export function getEnabledWeeks(): Promise<EnabledWeekDto[]> {
+  return apiRequest<EnabledWeekDto[]>({ method: "GET", url: "/enabled-weeks/" });
+}
+
+export function replaceEnabledWeeks(weekNumbers: number[]): Promise<EnabledWeekDto[]> {
+  return apiRequest<EnabledWeekDto[]>({
+    method: "PUT",
+    url: "/enabled-weeks/",
+    data: { week_numbers: weekNumbers },
+  });
+}
+
+export function getCurrentSystemConfig(): Promise<SystemConfigDto> {
+  return apiRequest<SystemConfigDto>({ method: "GET", url: "/system-config/current" });
+}
+
+export function updateCurrentSystemConfig(
+  payload: Partial<SystemConfigDto>,
+): Promise<SystemConfigDto> {
+  return apiRequest<SystemConfigDto>({
+    method: "PATCH",
+    url: "/system-config/current",
+    data: payload,
+  });
+}
+
+export function getWorkshopWeekMarks(
+  workshopId: number,
+  weekNumber: number,
+): Promise<MarkDto[]> {
+  return apiRequest<MarkDto[]>({
+    method: "GET",
+    url: `/marks/workshop/${workshopId}/week/${weekNumber}`,
+  });
+}
+
+export function createMark(payload: CreateMarkPayload): Promise<MarkDto> {
+  return apiRequest<MarkDto>({ method: "POST", url: "/marks/", data: payload });
+}
+
+export function updateMark(markId: number, payload: UpdateMarkPayload): Promise<MarkDto> {
+  return apiRequest<MarkDto>({
+    method: "PATCH",
+    url: `/marks/${markId}`,
+    data: payload,
+  });
+}
+

--- a/app/lib/services/user.ts
+++ b/app/lib/services/user.ts
@@ -1,14 +1,15 @@
 import { apiRequest } from "../axios-instance";
-
-export type UserDto = {
-    id: number;
-    name: string | null;
-    email: string | null;
-};
+import type { UserDto } from "../../interface/apiTypes";
 
 export type CreateUserInput = {
-    name: string;
+    first_name: string;
+    last_name: string;
+    display_name: string;
     email: string;
+    role: "UC" | "tutor";
+    password: string;
+    preferred_name?: string | null;
+    is_active?: boolean;
 };
 
 export type UpdateUserInput = Partial<CreateUserInput>;
@@ -16,11 +17,11 @@ export type UpdateUserInput = Partial<CreateUserInput>;
 export function getUsers(): Promise<UserDto[]> {
     return apiRequest<UserDto[]>({
         method: "GET",
-        url: "/users",
+        url: "/users/",
     });
 }
 
-export function getUserById(userId: number): Promise<UserDto> {
+export function getUserById(userId: string): Promise<UserDto> {
     return apiRequest<UserDto>({
         method: "GET",
         url: `/users/${userId}`,
@@ -30,21 +31,21 @@ export function getUserById(userId: number): Promise<UserDto> {
 export function createUser(payload: CreateUserInput): Promise<UserDto> {
     return apiRequest<UserDto>({
         method: "POST",
-        url: "/users",
+        url: "/users/",
         data: payload,
     });
 }
 
-export function updateUser(userId: number, payload: UpdateUserInput): Promise<UserDto> {
+export function updateUser(userId: string, payload: UpdateUserInput): Promise<UserDto> {
     return apiRequest<UserDto>({
-        method: "PUT",
+        method: "PATCH",
         url: `/users/${userId}`,
         data: payload,
     });
 }
 
-export function deleteUser(userId: number): Promise<{ success: boolean }> {
-    return apiRequest<{ success: boolean }>({
+export function deleteUser(userId: string): Promise<void> {
+    return apiRequest<void>({
         method: "DELETE",
         url: `/users/${userId}`,
     });

--- a/docs/frontend-integration-notes.md
+++ b/docs/frontend-integration-notes.md
@@ -1,0 +1,50 @@
+# Frontend Integration Notes
+
+Date: 2026-04-27
+
+## Integrated Frontend Flows
+
+- Added a frontend service layer for the existing FastAPI endpoints:
+  - `GET /api/users/`
+  - `GET|POST|PATCH|DELETE /api/workshops/`
+  - `GET /api/students/`
+  - `GET|PUT /api/enabled-weeks/`
+  - `GET|PATCH /api/system-config/current`
+  - `GET /api/marks/workshop/{workshop_id}/week/{week_number}`
+  - `POST|PATCH /api/marks/`
+- Hydrated frontend workshop/config state from backend data when the API is reachable.
+- Kept local fallback behavior for offline development and incomplete backend contracts.
+- Connected Settings save to enabled weeks and current system config endpoints.
+- Connected Review & Submit to create or update participation marks against existing mark endpoints.
+- Updated the user API helper to match the current backend `users` route shape.
+
+## Current Compatibility Gaps
+
+- Backend auth endpoints expected by the frontend are not currently registered:
+  - `POST /api/auth/login`
+  - `GET /api/auth/me`
+  - `POST /api/auth/logout`
+- The frontend can still use dev-only test login, but real credential login is blocked until backend auth exists.
+- There is no direct frontend-usable endpoint for "students currently in workshop".
+  - Backend has membership CRUD logic, but no route that lists current memberships by workshop.
+  - CSV-uploaded rosters therefore remain local frontend state for now.
+- Mark submission requires a backend user id.
+  - With dev login, the frontend tries to match the current email against `GET /api/users/`.
+  - If no matching backend user exists, marks remain saved locally and backend submission is skipped with an error message.
+- Workshop tutor assignment can only persist if the tutor email matches an existing backend user.
+
+## Smoke Testing
+
+- `npm run lint`: passed.
+- `npx tsc --noEmit`: passed.
+- `npm run build`: blocked by local Windows filesystem permissions on generated `.next` artifacts:
+  - initial failure: `EPERM` during rename in `.next/server`
+  - retry failure: `EPERM` during unlink in `.next/build/chunks`
+  - scoped `.next` cleanup also failed with permission denied, and escalated cleanup was declined.
+
+## Suggested Next Integration Tickets
+
+- Add backend auth routes matching the existing frontend contract.
+- Add workshop roster endpoint, for example `GET /api/workshops/{workshop_id}/students`.
+- Add CSV/import flow that creates students and memberships together.
+- Add an upsert/batch endpoint for marks to replace create-then-patch frontend orchestration.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Added frontend API types and service wrappers for existing participation endpoints
- Hydrated frontend workshop/config state from backend data when available
- Connected Settings save to enabled weeks and system config APIs
- Connected Review & Submit to backend mark create/update flow
- Documented integration status, smoke checks, and remaining backend contract gaps

## Testing
- npm run lint
- npx tsc --noEmit

## Notes
Backend files were not changed. Remaining blockers include missing auth endpoints and no direct workshop roster endpoint.
