### PR TITLE
Support student workshop reassignment with history preservation

### DIFF
--- a/api/partimark_app/api_version/v1/routes/students.py
+++ b/api/partimark_app/api_version/v1/routes/students.py
@@ -117,12 +117,31 @@ def move_student(
             detail="Target workshop not found.",
         )
 
-    new_membership = crud_memberships.move_student_to_workshop(
-        db=db,
+    current_memberships = crud_memberships.get_current_memberships_by_student(
+        db,
         student_id=student_id,
-        target_workshop_id=move_request.target_workshop_id,
-        created_by_user_id=move_request.created_by_user_id,
     )
+    if any(
+        membership.workshop_id == move_request.target_workshop_id
+        for membership in current_memberships
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Student is already assigned to the target workshop.",
+        )
+
+    try:
+        new_membership = crud_memberships.move_student_to_workshop(
+            db=db,
+            student_id=student_id,
+            target_workshop_id=move_request.target_workshop_id,
+            created_by_user_id=move_request.created_by_user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     return {
         "message": "Student moved successfully.",
@@ -130,6 +149,9 @@ def move_student(
         "student_id": new_membership.student_id,
         "workshop_id": new_membership.workshop_id,
         "is_current": new_membership.is_current,
+        "previous_workshop_ids": [
+            membership.workshop_id for membership in current_memberships
+        ],
     }
 
 

--- a/api/partimark_app/crud/crud_student_workshop_memberships.py
+++ b/api/partimark_app/crud/crud_student_workshop_memberships.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import List, Optional
 
 from sqlalchemy.orm import Session
@@ -40,6 +40,21 @@ def get_current_membership_by_student(
             StudentWorkshopMembership.is_current.is_(True),
         )
         .first()
+    )
+
+
+def get_current_memberships_by_student(
+    db: Session,
+    student_id: str,
+) -> List[StudentWorkshopMembership]:
+    """Retrieve every current workshop membership for a student."""
+    return (
+        db.query(StudentWorkshopMembership)
+        .filter(
+            StudentWorkshopMembership.student_id == student_id,
+            StudentWorkshopMembership.is_current.is_(True),
+        )
+        .all()
     )
 
 
@@ -91,7 +106,7 @@ def close_current_membership(
 ) -> StudentWorkshopMembership:
     """Mark the current membership as no longer current."""
     db_membership.is_current = False
-    db_membership.end_date = end_date or datetime.utcnow()
+    db_membership.end_date = end_date or datetime.now(UTC)
     db.commit()
     db.refresh(db_membership)
     return db_membership
@@ -109,10 +124,16 @@ def move_student_to_workshop(
 
     This closes the current membership (if any) and creates a new current membership.
     """
-    move_time = move_time or datetime.utcnow()
+    move_time = move_time or datetime.now(UTC)
 
-    current_membership = get_current_membership_by_student(db, student_id)
-    if current_membership is not None:
+    current_memberships = get_current_memberships_by_student(db, student_id)
+    if any(
+        membership.workshop_id == target_workshop_id
+        for membership in current_memberships
+    ):
+        raise ValueError("Student is already assigned to the target workshop.")
+
+    for current_membership in current_memberships:
         current_membership.is_current = False
         current_membership.end_date = move_time
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -6,11 +6,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-# Add the app directory to the system path to allow importing modules
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "partimark_app")))
+# Add the api directory to the system path to allow importing the app package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from partimark_app.db.db import Base, get_db  # type: ignore # noqa: E402
-from main import app  # type: ignore # noqa: E402
+from partimark_app.main import app  # type: ignore # noqa: E402
 
 # Use an in-memory SQLite database for testing to ensure isolation and speed
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"

--- a/api/tests/routes/test_students_endpoints.py
+++ b/api/tests/routes/test_students_endpoints.py
@@ -1,5 +1,12 @@
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from partimark_app.crud import crud_student_workshop_memberships as crud_memberships
+from partimark_app.models.enabled_weeks import EnabledWeek
+from partimark_app.models.marks import ParticipationMark
+from partimark_app.models.student_workshop_memberships import StudentWorkshopMembership
+from partimark_app.models.users import User, UserRole
 
 def test_create_student_route(client: TestClient):
     """Test the POST /api/students/ route creates a student successfully."""
@@ -11,14 +18,14 @@ def test_create_student_route(client: TestClient):
             "last_name": "Student",
             "preferred_name": "API Student",
             "email": "route.student@example.com",
-            "status": "enrolled",
+            "status": "active",
             "image_url": "http://example.com/image.jpg"
         }
     )
     assert response.status_code == 201
     data = response.json()
     assert data["student_id"] == "87654321"
-    assert data["status"] == "enrolled"
+    assert data["status"] == "active"
 
 def test_create_student_route_default_status(client: TestClient):
     """Test creating a student without providing status, expecting PyDantic to apply the default 'enrolled'."""
@@ -36,7 +43,7 @@ def test_create_student_route_default_status(client: TestClient):
     assert response.status_code == 201
     data = response.json()
     assert data["student_id"] == "99988877"
-    assert data["status"] == "enrolled"
+    assert data["status"] == "active"
 
 def test_create_student_duplicate_email(client: TestClient):
     """Test the POST /api/students/ route handles conflicts properly."""
@@ -46,7 +53,7 @@ def test_create_student_duplicate_email(client: TestClient):
         "last_name": "Student",
         "preferred_name": "Con",
         "email": "conflict@example.com",
-        "status": "enrolled",
+        "status": "active",
         "image_url": "http://example.com/image.jpg"
     }
     client.post("/api/students/", json=payload)
@@ -59,7 +66,7 @@ def test_get_students_route(client: TestClient):
     """Test the GET /api/students/ route to retrieve a list of students."""
     client.post("/api/students/", json={
         "student_id": "22222222", "first_name": "Get", "last_name": "User",
-        "preferred_name": "Get", "email": "get_test@example.com", "status": "enrolled", "image_url": "http://example.com/image.jpg"
+        "preferred_name": "Get", "email": "get_test@example.com", "status": "active", "image_url": "http://example.com/image.jpg"
     })
     
     response = client.get("/api/students/")
@@ -72,7 +79,7 @@ def test_get_student_route(client: TestClient):
     """Test the GET /api/students/{id} route retrieves the specific student."""
     client.post("/api/students/", json={
         "student_id": "33333333", "first_name": "Single", "last_name": "User",
-        "preferred_name": "Single", "email": "single@example.com", "status": "enrolled", "image_url": "http://example.com/image.jpg"
+        "preferred_name": "Single", "email": "single@example.com", "status": "active", "image_url": "http://example.com/image.jpg"
     })
     
     response = client.get("/api/students/33333333")
@@ -83,7 +90,7 @@ def test_update_student_route(client: TestClient):
     """Test the PATCH /api/students/{id} effectively updates fields."""
     client.post("/api/students/", json={
         "student_id": "44444444", "first_name": "Update", "last_name": "Me",
-        "preferred_name": "UpMe", "email": "update@example.com", "status": "enrolled", "image_url": "http://example.com/image.jpg"
+        "preferred_name": "UpMe", "email": "update@example.com", "status": "active", "image_url": "http://example.com/image.jpg"
     })
     
     response = client.patch("/api/students/44444444", json={
@@ -97,7 +104,7 @@ def test_delete_student_route(client: TestClient):
     """Test the DELETE /api/students/{id} properly removes the student."""
     client.post("/api/students/", json={
         "student_id": "55555555", "first_name": "Delete", "last_name": "Me",
-        "preferred_name": "Del", "email": "delete@example.com", "status": "enrolled", "image_url": "http://example.com/image.jpg"
+        "preferred_name": "Del", "email": "delete@example.com", "status": "active", "image_url": "http://example.com/image.jpg"
     })
     
     del_res = client.delete("/api/students/55555555")
@@ -105,3 +112,157 @@ def test_delete_student_route(client: TestClient):
     
     get_res = client.get("/api/students/55555555")
     assert get_res.status_code == 404
+
+
+def _create_student_for_move(client: TestClient, student_id: str = "77777777") -> None:
+    response = client.post("/api/students/", json={
+        "student_id": student_id,
+        "first_name": "Move",
+        "last_name": "Student",
+        "preferred_name": "Mover",
+        "email": f"{student_id}@example.com",
+        "status": "active",
+        "image_url": "http://example.com/image.jpg",
+    })
+    assert response.status_code == 201
+
+
+def _create_workshop(client: TestClient, workshop_name: str) -> int:
+    response = client.post("/api/workshops/", json={
+        "workshop_name": workshop_name,
+        "tutor_user_id": None,
+        "is_active": True,
+    })
+    assert response.status_code == 201
+    return response.json()["workshop_id"]
+
+
+def test_move_student_reassigns_current_membership_and_preserves_marks(
+    client: TestClient,
+    db_session: Session,
+):
+    _create_student_for_move(client)
+    old_workshop_id = _create_workshop(client, "Move Source Workshop")
+    new_workshop_id = _create_workshop(client, "Move Target Workshop")
+
+    original_membership = crud_memberships.move_student_to_workshop(
+        db_session,
+        student_id="77777777",
+        target_workshop_id=old_workshop_id,
+    )
+
+    marker = User(
+        user_id="marker-user",
+        email="marker@example.com",
+        hashed_password="not-used-in-test",
+        first_name="Marker",
+        last_name="User",
+        display_name="Marker User",
+        role=UserRole.TUTOR,
+        is_active=True,
+    )
+    db_session.add(marker)
+    db_session.add(EnabledWeek(week_number=1))
+    historical_mark = ParticipationMark(
+        student_id="77777777",
+        workshop_id=old_workshop_id,
+        week_number=1,
+        score=3,
+        marked_by_user_id=marker.user_id,
+    )
+    db_session.add(historical_mark)
+    db_session.commit()
+
+    response = client.post(
+        "/api/students/77777777/move",
+        json={"target_workshop_id": new_workshop_id},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["student_id"] == "77777777"
+    assert data["workshop_id"] == new_workshop_id
+    assert data["is_current"] is True
+    assert data["previous_workshop_ids"] == [old_workshop_id]
+
+    db_session.refresh(original_membership)
+    db_session.refresh(historical_mark)
+
+    assert original_membership.is_current is False
+    assert original_membership.end_date is not None
+    assert historical_mark.workshop_id == old_workshop_id
+    assert historical_mark.score == 3
+
+    current_memberships = crud_memberships.get_current_memberships_by_student(
+        db_session,
+        student_id="77777777",
+    )
+    assert len(current_memberships) == 1
+    assert current_memberships[0].workshop_id == new_workshop_id
+
+
+def test_move_student_rejects_nonexistent_target_workshop(client: TestClient):
+    _create_student_for_move(client, student_id="77777778")
+
+    response = client.post(
+        "/api/students/77777778/move",
+        json={"target_workshop_id": 999999},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Target workshop not found."
+
+
+def test_move_student_rejects_same_current_workshop(
+    client: TestClient,
+    db_session: Session,
+):
+    _create_student_for_move(client, student_id="77777779")
+    workshop_id = _create_workshop(client, "Move Same Workshop")
+    crud_memberships.move_student_to_workshop(
+        db_session,
+        student_id="77777779",
+        target_workshop_id=workshop_id,
+    )
+
+    response = client.post(
+        "/api/students/77777779/move",
+        json={"target_workshop_id": workshop_id},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student is already assigned to the target workshop."
+
+    current_memberships = crud_memberships.get_current_memberships_by_student(
+        db_session,
+        student_id="77777779",
+    )
+    assert len(current_memberships) == 1
+    assert current_memberships[0].workshop_id == workshop_id
+
+
+def test_crud_move_student_rejects_same_current_workshop(
+    client: TestClient,
+    db_session: Session,
+):
+    _create_student_for_move(client, student_id="77777780")
+    workshop_id = _create_workshop(client, "Move Same Workshop Crud")
+    crud_memberships.move_student_to_workshop(
+        db_session,
+        student_id="77777780",
+        target_workshop_id=workshop_id,
+    )
+
+    with pytest.raises(ValueError, match="already assigned"):
+        crud_memberships.move_student_to_workshop(
+            db_session,
+            student_id="77777780",
+            target_workshop_id=workshop_id,
+        )
+
+    current_memberships = crud_memberships.get_current_memberships_by_student(
+        db_session,
+        student_id="77777780",
+    )
+    assert len(current_memberships) == 1
+    assert current_memberships[0].workshop_id == workshop_id


### PR DESCRIPTION
## Summary
- Added validation for student workshop reassignment
- Prevented duplicate current memberships when moving students
- Preserved historical participation marks when changing workshop assignment
- Returned previous workshop IDs for traceability
- Added tests for successful reassignment, invalid target workshops, and duplicate moves

## Testing
- `venv\Scripts\python.exe -m pytest api\tests\routes\test_students_endpoints.py -q`

## Notes
Full backend test suite still has unrelated stale tests expecting old role/status enum values.
