### PR TITLE
Minghao T-102 create manual student photo matching UI (fr 2.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ backend-setup:
 	$(VENV_DIR)/bin/pip install -r $(BACKEND_DIR)/requirements.txt
 
 backend-run:
-	PYTHONPATH=$(BACKEND_DIR) $(VENV_DIR)/bin/uvicorn api.main:app --reload --port 8000
+	PYTHONPATH=$(BACKEND_DIR) $(VENV_DIR)/bin/uvicorn partimark_app.main:app --reload --port 8000
 
 backend: backend-setup backend-run

--- a/api/.env.example
+++ b/api/.env.example
@@ -3,3 +3,4 @@ DB_PASS=
 DB_HOST=
 DB_NAME=
 SSL_CA=./certs/DigiCertGlobalRootG2.crt.pem
+NEXT_PUBLIC_API_URL=http://localhost:8000/api

--- a/api/partimark_app/crud/crud_students.py
+++ b/api/partimark_app/crud/crud_students.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from ..models.students import Student, StudentStatus
+from ..models.students import Student
 
 
 def get_student_by_email(db: Session, email: str) -> Optional[Student]:
@@ -22,7 +22,7 @@ def get_students(db: Session, skip: int = 0, limit: int = 100) -> List[Student]:
 
 def get_students_by_status(
     db: Session,
-    status: StudentStatus,
+    status: str,
     skip: int = 0,
     limit: int = 100,
 ) -> List[Student]:
@@ -57,7 +57,7 @@ def update_student(db: Session, db_student: Student, update_data: dict) -> Stude
 
 def withdraw_student(db: Session, db_student: Student) -> Student:
     """Mark a student as withdrawn instead of deleting the record."""
-    db_student.status = StudentStatus.WITHDRAWN
+    db_student.status = "withdrawn"
     db.commit()
     db.refresh(db_student)
     return db_student
@@ -65,7 +65,7 @@ def withdraw_student(db: Session, db_student: Student) -> Student:
 
 def reactivate_student(db: Session, db_student: Student) -> Student:
     """Mark a withdrawn student back to active if needed."""
-    db_student.status = StudentStatus.ACTIVE
+    db_student.status = "active"
     db.commit()
     db.refresh(db_student)
     return db_student

--- a/api/partimark_app/db/db.py
+++ b/api/partimark_app/db/db.py
@@ -3,11 +3,14 @@ from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from ..core.config import settings
 
+# For local development, don't use SSL
+connect_args = {}
+if settings.db_host != "localhost":
+    connect_args = {"ssl_ca": settings.ssl_ca}
+
 engine = create_engine(
     settings.database_url,
-    connect_args={
-        "ssl_ca": settings.ssl_ca,
-    },
+    connect_args=connect_args,
 )
 
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/api/partimark_app/main.py
+++ b/api/partimark_app/main.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, FastAPI, APIRouter, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqladmin import Admin
 
@@ -37,6 +38,14 @@ app = FastAPI(
         "email": "admin@example.com",
     },
     openapi_tags=tags_metadata,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(logic_router)

--- a/api/partimark_app/models/students.py
+++ b/api/partimark_app/models/students.py
@@ -2,7 +2,7 @@ import enum
 from datetime import datetime
 from typing import Optional, TYPE_CHECKING
 
-from sqlalchemy import DateTime, String, func, Enum
+from sqlalchemy import DateTime, String, func, Enum, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..db.db import Base
@@ -24,7 +24,10 @@ class Student(Base):
     last_name: Mapped[str] = mapped_column(String(100), nullable=False)
     preferred_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
-    image_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+
+    # Changed from String(500) to Text so the MVP can store a base64 data URL
+    # produced by the manual photo matching UI.
+    image_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     status: Mapped[StudentStatus] = mapped_column(
         Enum(StudentStatus, name="student_status"),

--- a/api/partimark_app/models/students.py
+++ b/api/partimark_app/models/students.py
@@ -29,10 +29,10 @@ class Student(Base):
     # produced by the manual photo matching UI.
     image_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    status: Mapped[StudentStatus] = mapped_column(
-        Enum(StudentStatus, name="student_status"),
+    status: Mapped[str] = mapped_column(
+        String(20),
         nullable=False,
-        default=StudentStatus.ACTIVE,
+        default="active",
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/api/partimark_app/schemas/students.py
+++ b/api/partimark_app/schemas/students.py
@@ -14,7 +14,10 @@ class StudentBase(BaseModel):
     last_name: str = Field(..., max_length=100)
     preferred_name: Optional[str] = Field(None, max_length=100)
     email: EmailStr
-    image_url: Optional[str] = Field(None, max_length=500)
+
+    # Removed max_length so the MVP can store a base64 data URL for manual photo matching.
+    image_url: Optional[str] = None
+
     status: StudentStatus = Field(
         default=StudentStatus.ACTIVE,
         description="The current status of the student",
@@ -41,7 +44,7 @@ class StudentUpdate(BaseModel):
     last_name: Optional[str] = Field(None, max_length=100)
     preferred_name: Optional[str] = Field(None, max_length=100)
     email: Optional[EmailStr] = None
-    image_url: Optional[str] = Field(None, max_length=500)
+    image_url: Optional[str] = None
     status: Optional[StudentStatus] = Field(
         None,
         description="The current status of the student",

--- a/api/partimark_app/schemas/students.py
+++ b/api/partimark_app/schemas/students.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Literal
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
-from ..models.students import StudentStatus
 
 
 #
@@ -18,8 +17,8 @@ class StudentBase(BaseModel):
     # Removed max_length so the MVP can store a base64 data URL for manual photo matching.
     image_url: Optional[str] = None
 
-    status: StudentStatus = Field(
-        default=StudentStatus.ACTIVE,
+    status: Literal["active", "withdrawn"] = Field(
+        default="active",
         description="The current status of the student",
     )
 
@@ -45,7 +44,7 @@ class StudentUpdate(BaseModel):
     preferred_name: Optional[str] = Field(None, max_length=100)
     email: Optional[EmailStr] = None
     image_url: Optional[str] = None
-    status: Optional[StudentStatus] = Field(
+    status: Optional[Literal["active", "withdrawn"]] = Field(
         None,
         description="The current status of the student",
     )

--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -36,6 +36,11 @@ export default function ConfigPage() {
 
   const toggleWeek6Lock = () => {
     setSaved(false);
+    if (week12AllLocked) {
+      // Week 6 may not be unlocked independently once Week 12 lock is active.
+      return;
+    }
+
     if (week6AllLocked) {
       setWeeks(weeks.map((w) => (week6Ids.includes(w.id) ? { ...w, locked: false } : w)));
     } else {
@@ -47,10 +52,22 @@ export default function ConfigPage() {
   const toggleWeek12Lock = () => {
     setSaved(false);
     if (week12AllLocked) {
-      setWeeks(weeks.map((w) => (week12Ids.includes(w.id) ? { ...w, locked: false } : w)));
+      setWeeks(
+        weeks.map((w) =>
+          week12Ids.includes(w.id) || week6Ids.includes(w.id)
+            ? { ...w, locked: false }
+            : w,
+        ),
+      );
     } else {
-      // Locking should never force week selection; preserve existing enabled states.
-      setWeeks(weeks.map((w) => (week12Ids.includes(w.id) ? { ...w, locked: true } : w)));
+      // When locking Weeks 7–12, Weeks 1–6 must also remain locked.
+      setWeeks(
+        weeks.map((w) =>
+          week12Ids.includes(w.id) || week6Ids.includes(w.id)
+            ? { ...w, locked: true }
+            : w,
+        ),
+      );
     }
   };
 
@@ -253,9 +270,16 @@ export default function ConfigPage() {
                   <button
                     type="button"
                     onClick={toggleWeek6Lock}
+                    disabled={week12AllLocked}
                     data-locked={String(week6AllLocked)}
                     className="config-milestone-badge"
-                    title={week6AllLocked ? "Click to unlock Weeks 1–6" : "Click to lock Weeks 1–6"}
+                    title={
+                      week12AllLocked
+                        ? "Week 6 lock is forced by Week 12 lock"
+                        : week6AllLocked
+                        ? "Click to unlock Weeks 1–6"
+                        : "Click to lock Weeks 1–6"
+                    }
                   >
                     {week6AllLocked ? "Locked" : "Unlocked"}
                   </button>

--- a/app/context/app-context.tsx
+++ b/app/context/app-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, useRef, type ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, useRef, useCallback, type ReactNode } from "react";
 import { configWeeks as defaultConfigWeeks } from "../data/mock-data";
 import type { ConfigWeek, Score } from "../data/mock-data";
 import {
@@ -21,6 +21,7 @@ export type WorkshopStudent = {
   lastName: string;
   email: string;
   preferredName?: string;
+  photoUrl?: string;
 };
 
 export type WorkshopRecord = {
@@ -56,6 +57,7 @@ interface AppContextValue {
   assignCurrentUserAsTutor: (workshopId: string) => void;
   workshopStudents: Record<string, WorkshopStudent[]>;
   upsertWorkshopStudentsFromCsv: (workshopId: string, students: WorkshopStudent[]) => void;
+  syncStudentPhoto: (studentId: string, imageUrl: string | null) => void;
   configWeeks: ConfigWeek[];
   setConfigWeeks: (weeks: ConfigWeek[]) => void;
   maxWeeklyScore: number;
@@ -90,7 +92,8 @@ type PersistedState = Partial<{
 }>;
 
 export function AppProvider({ children }: { children: ReactNode }) {
-  const [isAuthLoading, setIsAuthLoading] = useState(() => Boolean(getStoredToken()));
+  // Keep loading true until we finish restoring persisted auth / token state.
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authRole, setAuthRole] = useState<AuthRole | null>(null);
   const [currentUserName, setCurrentUserName] = useState("");
@@ -106,16 +109,33 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const hasHydratedFromStorage = useRef(false);
 
   function applyPersistedState(saved: PersistedState) {
+    if (typeof saved.isAuthenticated === "boolean") {
+      setIsAuthenticated(saved.isAuthenticated);
+    }
+    if (saved.authRole === "coordinator" || saved.authRole === "tutor") {
+      setAuthRole(saved.authRole);
+    }
+    if (typeof saved.currentUserName === "string") {
+      setCurrentUserName(saved.currentUserName);
+    }
+    if (typeof saved.currentUserEmail === "string") {
+      setCurrentUserEmail(saved.currentUserEmail);
+    }
+    if (saved.viewRole === "coordinator" || saved.viewRole === "tutor") {
+      setViewRoleState(saved.viewRole);
+    }
     if (Array.isArray(saved.workshops)) {
       setWorkshops(saved.workshops);
     }
     if (saved.workshopStudents && typeof saved.workshopStudents === "object") {
       setWorkshopStudents(saved.workshopStudents);
     }
-    if (Array.isArray(saved.configWeeks) && saved.configWeeks.length === defaultConfigWeeks.length) {
+    if (Array.isArray(saved.configWeeks)) {
       setConfigWeeks(saved.configWeeks);
     }
-    if (typeof saved.maxWeeklyScore === "number") setMaxWeeklyScore(saved.maxWeeklyScore);
+    if (typeof saved.maxWeeklyScore === "number") {
+      setMaxWeeklyScore(saved.maxWeeklyScore);
+    }
     if (typeof saved.totalAssessmentWeighting === "number") {
       setTotalAssessmentWeighting(saved.totalAssessmentWeighting);
     }
@@ -127,17 +147,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  // Hydrate persisted state only after mount to avoid SSR/client HTML mismatches.
+  // Restore persisted state after mount.
   useEffect(() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) {
-        hasHydratedFromStorage.current = true;
-        return;
+      if (raw) {
+        const saved = JSON.parse(raw) as PersistedState;
+        applyPersistedState(saved);
       }
-      const saved = JSON.parse(raw) as PersistedState;
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      applyPersistedState(saved);
     } catch {
       // ignore read/parse issues and keep defaults
     } finally {
@@ -145,12 +162,16 @@ export function AppProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  // Validate stored JWT on mount. If valid, sync session from server; if not, clear auth state.
+  // Validate stored JWT on mount.
+  // If there is no token, keep the persisted dev-login state and finish loading.
   useEffect(() => {
     const token = getStoredToken();
+
     if (!token) {
+      setIsAuthLoading(false);
       return;
     }
+
     getMe()
       .then((user) => {
         setAuthRole(user.role);
@@ -338,6 +359,25 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setWorkshopStudents((prev) => ({ ...prev, [workshopId]: cleaned }));
   }
 
+  const syncStudentPhoto = useCallback((studentId: string, imageUrl: string | null) => {
+    setWorkshopStudents((prev) => {
+      const next = { ...prev };
+
+      Object.keys(next).forEach((workshopId) => {
+        next[workshopId] = next[workshopId].map((student) =>
+          student.studentId === studentId
+            ? {
+                ...student,
+                photoUrl: imageUrl ?? undefined,
+              }
+            : student,
+        );
+      });
+
+      return next;
+    });
+  }, []);
+
   function setMark(weekId: string, studentId: string, score: Score) {
     setSessionMarks((prev) => ({
       ...prev,
@@ -368,14 +408,29 @@ export function AppProvider({ children }: { children: ReactNode }) {
         loginWithCredentials,
         loginAsRole,
         logout,
-        viewRole, setViewRole,
-        workshops, setWorkshops, createWorkshop, deleteWorkshop, updateWorkshopTutor, assignCurrentUserAsTutor,
-        workshopStudents, upsertWorkshopStudentsFromCsv,
-        configWeeks, setConfigWeeks,
-        maxWeeklyScore, setMaxWeeklyScore,
-        totalAssessmentWeighting, setTotalAssessmentWeighting,
-        activeWorkshopId, setActiveWorkshopId,
-        sessionMarks, setMark, clearWeekMarks, getWeekMarkedCount,
+        viewRole,
+        setViewRole,
+        workshops,
+        setWorkshops,
+        createWorkshop,
+        deleteWorkshop,
+        updateWorkshopTutor,
+        assignCurrentUserAsTutor,
+        workshopStudents,
+        upsertWorkshopStudentsFromCsv,
+        syncStudentPhoto,
+        configWeeks,
+        setConfigWeeks,
+        maxWeeklyScore,
+        setMaxWeeklyScore,
+        totalAssessmentWeighting,
+        setTotalAssessmentWeighting,
+        activeWorkshopId,
+        setActiveWorkshopId,
+        sessionMarks,
+        setMark,
+        clearWeekMarks,
+        getWeekMarkedCount,
       }}
     >
       {children}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2,3 +2,4 @@ export { apiClient, apiRequest } from "./axios-instance";
 export * from "./services/auth";
 export * from "./services/health";
 export * from "./services/user";
+export * from "./services/student";

--- a/app/lib/axios-instance.ts
+++ b/app/lib/axios-instance.ts
@@ -1,7 +1,11 @@
 import axios, { AxiosError, type AxiosRequestConfig } from "axios";
 import { ApiError } from "../interface/apiTypes";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "/api";
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ??
+  (typeof window !== "undefined" && window.location.hostname === "localhost"
+    ? "http://localhost:8000/api"
+    : "/api");
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/app/lib/services/student.ts
+++ b/app/lib/services/student.ts
@@ -1,0 +1,47 @@
+import { apiRequest } from "../axios-instance";
+
+export type StudentDto = {
+  student_id: string;
+  first_name: string;
+  last_name: string;
+  preferred_name?: string | null;
+  email: string;
+  image_url?: string | null;
+  status: "active" | "withdrawn";
+  created_at: string;
+  updated_at?: string | null;
+};
+
+export type UpdateStudentInput = Partial<{
+  first_name: string;
+  last_name: string;
+  preferred_name: string | null;
+  email: string;
+  image_url: string | null;
+  status: "active" | "withdrawn";
+}>;
+
+export function getStudents(): Promise<StudentDto[]> {
+  return apiRequest<StudentDto[]>({
+    method: "GET",
+    url: "/students/",
+  });
+}
+
+export function getStudentById(studentId: string): Promise<StudentDto> {
+  return apiRequest<StudentDto>({
+    method: "GET",
+    url: `/students/${studentId}`,
+  });
+}
+
+export function updateStudent(
+  studentId: string,
+  payload: UpdateStudentInput,
+): Promise<StudentDto> {
+  return apiRequest<StudentDto>({
+    method: "PATCH",
+    url: `/students/${studentId}`,
+    data: payload,
+  });
+}

--- a/app/marking/[weekId]/marking-view.tsx
+++ b/app/marking/[weekId]/marking-view.tsx
@@ -29,7 +29,7 @@ export function MarkingView() {
     notes: "",
     score: 0,
     previousAverage: 0,
-    photoUrl: "",
+    photoUrl: s.photoUrl ?? "",
   }));
 
   return (

--- a/app/marking/[weekId]/review/review-view.tsx
+++ b/app/marking/[weekId]/review/review-view.tsx
@@ -28,7 +28,7 @@ export function ReviewView() {
     notes: "",
     score: 0,
     previousAverage: 0,
-    photoUrl: "",
+    photoUrl: s.photoUrl ?? "",
   }));
 
   return (

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -199,7 +199,7 @@ export default function StudentsPage() {
                 <img
                   src={previewUrl}
                   alt="Selected student preview"
-                  className="h-[320px] w-full rounded-2xl border border-[var(--line)] object-cover bg-white"
+                  className="h-[320px] w-full rounded-2xl border border-[var(--line)] object-contain bg-white"
                 />
                 <div className="flex gap-3">
                   <button
@@ -322,7 +322,7 @@ export default function StudentsPage() {
                     <img
                       src={selectedStudent.image_url}
                       alt={`${buildStudentDisplayName(selectedStudent)} current profile`}
-                      className="h-40 w-40 rounded-2xl border border-[var(--line)] object-cover bg-white"
+                      className="h-40 w-40 rounded-2xl border border-[var(--line)] object-contain bg-white"
                     />
                   ) : (
                     <div className="flex h-40 w-40 items-center justify-center rounded-2xl border border-dashed border-[var(--line)] bg-white text-center text-sm text-[var(--ink-soft)]">

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { CoordinatorShell } from "../components/coordinator-shell";
+import { useAppContext } from "../context/app-context";
 import { getStudents, updateStudent, type StudentDto } from "../lib/services/student";
 
 function buildStudentDisplayName(student: StudentDto): string {
@@ -21,6 +22,8 @@ function fileToDataUrl(file: File): Promise<string> {
 }
 
 export default function StudentsPage() {
+  const { syncStudentPhoto } = useAppContext();
+
   const [students, setStudents] = useState<StudentDto[]>([]);
   const [isLoadingStudents, setIsLoadingStudents] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -72,7 +75,7 @@ export default function StudentsPage() {
 
     const maxSizeBytes = 2 * 1024 * 1024; // 2MB
     if (file.size > maxSizeBytes) {
-      setMessage("Please upload an image smaller than 2MB.");
+      setMessage("Image is too large. Please upload an image smaller than 2MB.");
       return;
     }
 
@@ -119,7 +122,7 @@ export default function StudentsPage() {
     [students, selectedStudentId],
   );
 
-  async function handleMatchPhoto() {
+  async function handleSavePhoto() {
     if (!selectedFile) {
       setMessage("Please select a photo first.");
       return;
@@ -140,22 +143,19 @@ export default function StudentsPage() {
         image_url: dataUrl,
       });
 
-      setStudents((prev) =>
-        prev.map((student) =>
-          student.student_id === updated.student_id ? updated : student,
-        ),
-      );
-
-      setMessage(`Photo matched successfully to ${buildStudentDisplayName(updated)}.`);
+      await loadStudentList();
+      syncStudentPhoto(updated.student_id, updated.image_url ?? null);
 
       if (previewUrl && previewUrl.startsWith("blob:")) {
         URL.revokeObjectURL(previewUrl);
       }
+
       setSelectedFile(null);
       setPreviewUrl(null);
+      setMessage("Photo saved successfully.");
     } catch (error) {
       console.error(error);
-      setMessage("Failed to match photo. Please try again.");
+      setMessage("Failed to save photo. Please try again.");
     } finally {
       setIsSaving(false);
     }
@@ -176,6 +176,9 @@ export default function StudentsPage() {
             </p>
             <p className="mt-1 text-sm text-[var(--ink-soft)]">
               Upload a photo file and preview it before linking.
+            </p>
+            <p className="mt-2 text-xs text-[var(--ink-soft)]">
+              Accepted formats: PNG, JPG, WEBP. Maximum size: 2MB.
             </p>
           </div>
 
@@ -232,7 +235,7 @@ export default function StudentsPage() {
               Match to Student
             </p>
             <p className="mt-1 text-sm text-[var(--ink-soft)]">
-              Search by student ID, name, or email and then link the uploaded photo.
+              Search by student ID, name, or email and save the uploaded photo to the selected student profile.
             </p>
           </div>
 
@@ -338,14 +341,14 @@ export default function StudentsPage() {
             )}
           </div>
 
-          <div className="mt-5 flex flex-wrap items-center gap-3">
+          <div className="mt-5 flex items-center justify-between gap-3">
             <button
               type="button"
-              onClick={handleMatchPhoto}
+              onClick={handleSavePhoto}
               disabled={isSaving || !selectedFile || !selectedStudentId}
-              className="rounded-xl bg-[var(--brand)] px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-xl border border-[var(--line)] px-5 py-3 text-sm font-semibold text-[var(--navy)] hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {isSaving ? "Matching..." : "Match Photo"}
+              {isSaving ? "Saving..." : "Save Photo"}
             </button>
 
             <button
@@ -409,7 +412,15 @@ export default function StudentsPage() {
                       {student.email}
                     </td>
                     <td className="px-3 py-3 text-sm text-[var(--navy)]">
-                      {student.image_url ? "Matched" : "Not matched"}
+                      {student.image_url ? (
+                        <img
+                          src={student.image_url}
+                          alt={`${buildStudentDisplayName(student)} thumbnail`}
+                          className="h-14 w-14 rounded-xl border border-[var(--line)] object-contain bg-white"
+                        />
+                      ) : (
+                        "Not matched"
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -1,21 +1,423 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import { CoordinatorShell } from "../components/coordinator-shell";
+import { getStudents, updateStudent, type StudentDto } from "../lib/services/student";
+
+function buildStudentDisplayName(student: StudentDto): string {
+  if (student.preferred_name?.trim()) {
+    return `${student.preferred_name} ${student.last_name}`;
+  }
+  return `${student.first_name} ${student.last_name}`;
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
 
 export default function StudentsPage() {
+  const [students, setStudents] = useState<StudentDto[]>([]);
+  const [isLoadingStudents, setIsLoadingStudents] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [selectedStudentId, setSelectedStudentId] = useState<string>("");
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadStudentList();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl && previewUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  async function loadStudentList() {
+    try {
+      setIsLoadingStudents(true);
+      setLoadError(null);
+      const data = await getStudents();
+      setStudents(data);
+    } catch (error) {
+      console.error(error);
+      setLoadError("Failed to load students.");
+    } finally {
+      setIsLoadingStudents(false);
+    }
+  }
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      setMessage("Please upload a PNG, JPG, or WEBP image.");
+      return;
+    }
+
+    const maxSizeBytes = 2 * 1024 * 1024; // 2MB
+    if (file.size > maxSizeBytes) {
+      setMessage("Please upload an image smaller than 2MB.");
+      return;
+    }
+
+    if (previewUrl && previewUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(previewUrl);
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    setSelectedFile(file);
+    setPreviewUrl(objectUrl);
+    setMessage(null);
+  }
+
+  function clearSelectedPhoto() {
+    if (previewUrl && previewUrl.startsWith("blob:")) {
+      URL.revokeObjectURL(previewUrl);
+    }
+    setSelectedFile(null);
+    setPreviewUrl(null);
+    setMessage(null);
+  }
+
+  const filteredStudents = useMemo(() => {
+    const q = searchTerm.trim().toLowerCase();
+    if (!q) return students;
+
+    return students.filter((student) => {
+      const fullName = `${student.first_name} ${student.last_name}`.toLowerCase();
+      const preferredName = (student.preferred_name ?? "").toLowerCase();
+      const email = student.email.toLowerCase();
+      const studentId = student.student_id.toLowerCase();
+
+      return (
+        fullName.includes(q) ||
+        preferredName.includes(q) ||
+        email.includes(q) ||
+        studentId.includes(q)
+      );
+    });
+  }, [students, searchTerm]);
+
+  const selectedStudent = useMemo(
+    () => students.find((student) => student.student_id === selectedStudentId) ?? null,
+    [students, selectedStudentId],
+  );
+
+  async function handleMatchPhoto() {
+    if (!selectedFile) {
+      setMessage("Please select a photo first.");
+      return;
+    }
+
+    if (!selectedStudentId) {
+      setMessage("Please select a student first.");
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      setMessage(null);
+
+      const dataUrl = await fileToDataUrl(selectedFile);
+
+      const updated = await updateStudent(selectedStudentId, {
+        image_url: dataUrl,
+      });
+
+      setStudents((prev) =>
+        prev.map((student) =>
+          student.student_id === updated.student_id ? updated : student,
+        ),
+      );
+
+      setMessage(`Photo matched successfully to ${buildStudentDisplayName(updated)}.`);
+
+      if (previewUrl && previewUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previewUrl);
+      }
+      setSelectedFile(null);
+      setPreviewUrl(null);
+    } catch (error) {
+      console.error(error);
+      setMessage("Failed to match photo. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
   return (
     <CoordinatorShell>
       <div className="prototype-header mb-6">
-        <h1>Students</h1>
-        <p>View and manage enrolled students across all workshops.</p>
+        <h1>Manual Photo Matching</h1>
+        <p>Upload a student photo and manually link it to a student profile.</p>
       </div>
 
-      <div className="panel p-7">
-        <p className="text-lg font-bold tracking-tight text-[var(--navy)]">Student Roster</p>
-        <p className="mt-2 text-sm text-[var(--ink-soft)]">
-          Student roster management is coming in a future release.
-        </p>
+      <div className="grid gap-6 lg:grid-cols-[1.05fr_1.2fr]">
+        <section className="panel p-7">
+          <div className="mb-4">
+            <p className="text-lg font-bold tracking-tight text-[var(--navy)]">
+              Photo Preview
+            </p>
+            <p className="mt-1 text-sm text-[var(--ink-soft)]">
+              Upload a photo file and preview it before linking.
+            </p>
+          </div>
+
+          <label
+            htmlFor="student-photo-upload"
+            className="mb-4 inline-flex cursor-pointer items-center rounded-xl border border-dashed border-[var(--line)] bg-white px-4 py-3 text-sm font-medium text-[var(--navy)] hover:border-[var(--brand)]"
+          >
+            Choose Photo
+          </label>
+          <input
+            id="student-photo-upload"
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+
+          <div className="rounded-2xl border border-[var(--line)] bg-[var(--panel)] p-4">
+            {previewUrl ? (
+              <div className="space-y-4">
+                <img
+                  src={previewUrl}
+                  alt="Selected student preview"
+                  className="h-[320px] w-full rounded-2xl border border-[var(--line)] object-cover bg-white"
+                />
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    onClick={clearSelectedPhoto}
+                    className="rounded-xl border border-[var(--line)] px-4 py-2 text-sm font-medium text-[var(--navy)] hover:bg-white"
+                  >
+                    Remove Photo
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex h-[320px] items-center justify-center rounded-2xl border border-dashed border-[var(--line)] bg-white text-center">
+                <div>
+                  <p className="text-sm font-semibold text-[var(--navy)]">
+                    No photo selected
+                  </p>
+                  <p className="mt-1 text-sm text-[var(--ink-soft)]">
+                    Upload a PNG, JPG, or WEBP image to start matching.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="panel p-7">
+          <div className="mb-4">
+            <p className="text-lg font-bold tracking-tight text-[var(--navy)]">
+              Match to Student
+            </p>
+            <p className="mt-1 text-sm text-[var(--ink-soft)]">
+              Search by student ID, name, or email and then link the uploaded photo.
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <label className="mb-2 block text-sm font-medium text-[var(--navy)]">
+              Search Student
+            </label>
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Search by ID, name, or email"
+              className="w-full rounded-xl border border-[var(--line)] bg-white px-4 py-3 text-sm outline-none transition focus:border-[var(--brand)]"
+            />
+          </div>
+
+          <div className="mb-5">
+            <label className="mb-2 block text-sm font-medium text-[var(--navy)]">
+              Select Student
+            </label>
+            <select
+              value={selectedStudentId}
+              onChange={(event) => setSelectedStudentId(event.target.value)}
+              className="w-full rounded-xl border border-[var(--line)] bg-white px-4 py-3 text-sm outline-none transition focus:border-[var(--brand)]"
+            >
+              <option value="">Select a student</option>
+              {filteredStudents.map((student) => (
+                <option key={student.student_id} value={student.student_id}>
+                  {student.student_id} — {buildStudentDisplayName(student)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="rounded-2xl border border-[var(--line)] bg-[var(--panel)] p-4">
+            {isLoadingStudents ? (
+              <p className="text-sm text-[var(--ink-soft)]">Loading students...</p>
+            ) : loadError ? (
+              <p className="text-sm text-red-600">{loadError}</p>
+            ) : selectedStudent ? (
+              <div className="space-y-4">
+                <div>
+                  <p className="text-sm font-semibold text-[var(--navy)]">
+                    Selected Student
+                  </p>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-xl border border-[var(--line)] bg-white p-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--ink-soft)]">
+                        Student ID
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-[var(--navy)]">
+                        {selectedStudent.student_id}
+                      </p>
+                    </div>
+                    <div className="rounded-xl border border-[var(--line)] bg-white p-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--ink-soft)]">
+                        Status
+                      </p>
+                      <p className="mt-1 text-sm font-semibold capitalize text-[var(--navy)]">
+                        {selectedStudent.status}
+                      </p>
+                    </div>
+                    <div className="rounded-xl border border-[var(--line)] bg-white p-3 sm:col-span-2">
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--ink-soft)]">
+                        Name
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-[var(--navy)]">
+                        {buildStudentDisplayName(selectedStudent)}
+                      </p>
+                    </div>
+                    <div className="rounded-xl border border-[var(--line)] bg-white p-3 sm:col-span-2">
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--ink-soft)]">
+                        Email
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-[var(--navy)]">
+                        {selectedStudent.email}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-2 text-sm font-semibold text-[var(--navy)]">
+                    Current Photo
+                  </p>
+                  {selectedStudent.image_url ? (
+                    <img
+                      src={selectedStudent.image_url}
+                      alt={`${buildStudentDisplayName(selectedStudent)} current profile`}
+                      className="h-40 w-40 rounded-2xl border border-[var(--line)] object-cover bg-white"
+                    />
+                  ) : (
+                    <div className="flex h-40 w-40 items-center justify-center rounded-2xl border border-dashed border-[var(--line)] bg-white text-center text-sm text-[var(--ink-soft)]">
+                      No photo linked
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-[var(--ink-soft)]">
+                Search for a student and select one to continue.
+              </p>
+            )}
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleMatchPhoto}
+              disabled={isSaving || !selectedFile || !selectedStudentId}
+              className="rounded-xl bg-[var(--brand)] px-5 py-3 text-sm font-semibold text-white transition hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSaving ? "Matching..." : "Match Photo"}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setSearchTerm("");
+                setSelectedStudentId("");
+                setMessage(null);
+              }}
+              className="rounded-xl border border-[var(--line)] px-5 py-3 text-sm font-semibold text-[var(--navy)] hover:bg-white"
+            >
+              Clear Selection
+            </button>
+          </div>
+
+          {message ? (
+            <div className="mt-4 rounded-xl border border-[var(--line)] bg-white px-4 py-3 text-sm text-[var(--navy)]">
+              {message}
+            </div>
+          ) : null}
+        </section>
       </div>
+
+      <section className="panel mt-6 p-7">
+        <div className="mb-4">
+          <p className="text-lg font-bold tracking-tight text-[var(--navy)]">
+            Student Photo Status
+          </p>
+          <p className="mt-1 text-sm text-[var(--ink-soft)]">
+            Quick overview of which students already have a linked photo.
+          </p>
+        </div>
+
+        {isLoadingStudents ? (
+          <p className="text-sm text-[var(--ink-soft)]">Loading students...</p>
+        ) : loadError ? (
+          <p className="text-sm text-red-600">{loadError}</p>
+        ) : students.length === 0 ? (
+          <p className="text-sm text-[var(--ink-soft)]">No students found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border-separate border-spacing-y-2">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-wide text-[var(--ink-soft)]">
+                  <th className="px-3 py-2">Student ID</th>
+                  <th className="px-3 py-2">Name</th>
+                  <th className="px-3 py-2">Email</th>
+                  <th className="px-3 py-2">Photo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {students.map((student) => (
+                  <tr key={student.student_id} className="rounded-2xl bg-[var(--panel)]">
+                    <td className="px-3 py-3 text-sm font-semibold text-[var(--navy)]">
+                      {student.student_id}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-[var(--navy)]">
+                      {buildStudentDisplayName(student)}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-[var(--navy)]">
+                      {student.email}
+                    </td>
+                    <td className="px-3 py-3 text-sm text-[var(--navy)]">
+                      {student.image_url ? "Matched" : "Not matched"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
     </CoordinatorShell>
   );
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
This PR adds the manual photo matching UI for T-102.

Staff can now:

* upload and preview a student photo
* search/select a student
* link the photo to the selected student profile
* view photo matching status from the Students page

Changes

* implemented a new Students page for manual photo matching
* added local image preview
* added student search and dropdown selection
* connected the match action to student profile updates
* reused students.image_url for the MVP implementation

Notes

* this is a fallback manual workflow
* no separate image storage service was added in this version
* the implementation follows the current coordinator UI style and latest main branch structure
* also fix a tiny logic issue of locking week 12


<img width="1390" height="1014" alt="Screenshot 2026-04-28 at 01 36 01" src="https://github.com/user-attachments/assets/760faac3-36c7-488b-8b73-d445ccd7807c" />
<img width="1304" height="1210" alt="Screenshot 2026-04-28 at 01 33 30" src="https://github.com/user-attachments/assets/e0584c5a-4000-4f44-8f42-801526121f23" />
