### PR TITLE
fix: lock max weekly score to 3 (MVP scope)

### DIFF
--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -9,7 +9,6 @@ export default function ConfigPage() {
     configWeeks: weeks,
     setConfigWeeks: setWeeks,
     maxWeeklyScore,
-    setMaxWeeklyScore,
     totalAssessmentWeighting,
     setTotalAssessmentWeighting,
   } = useAppContext();
@@ -151,22 +150,17 @@ export default function ConfigPage() {
               </div>
 
               <div className="config-field">
-                <label htmlFor="max-weekly-score" className="config-field-label">
-                  Max Weekly Score
-                </label>
-                <input
-                  id="max-weekly-score"
-                  type="number"
-                  min={1}
-                  max={3}
-                  value={maxWeeklyScore}
-                  onChange={(e) => {
-                    setSaved(false);
-                    const v = Number(e.target.value);
-                    if (!Number.isNaN(v) && v >= 1 && v <= 3) setMaxWeeklyScore(v);
-                  }}
-                  className="config-field-input"
-                />
+                <label className="config-field-label">Max Weekly Score</label>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <input
+                    type="number"
+                    value={3}
+                    readOnly
+                    className="config-field-input"
+                    style={{ opacity: 0.6, cursor: "not-allowed", width: 80 }}
+                  />
+                  <span style={{ fontSize: 12, color: "var(--ink-soft)" }}>Fixed per MVP scope</span>
+                </div>
               </div>
 
               <div className="config-field">

--- a/app/config/page.tsx
+++ b/app/config/page.tsx
@@ -150,17 +150,14 @@ export default function ConfigPage() {
               </div>
 
               <div className="config-field">
-                <label className="config-field-label">Max Weekly Score</label>
-                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                  <input
-                    type="number"
-                    value={3}
-                    readOnly
-                    className="config-field-input"
-                    style={{ opacity: 0.6, cursor: "not-allowed", width: 80 }}
-                  />
-                  <span style={{ fontSize: 12, color: "var(--ink-soft)" }}>Fixed per MVP scope</span>
-                </div>
+                <label htmlFor="max-weekly-score" className="config-field-label">Max Weekly Score</label>
+                <input
+                  id="max-weekly-score"
+                  type="number"
+                  value={3}
+                  readOnly
+                  className="config-field-input"
+                />
               </div>
 
               <div className="config-field">

--- a/app/context/app-context.tsx
+++ b/app/context/app-context.tsx
@@ -59,7 +59,6 @@ interface AppContextValue {
   configWeeks: ConfigWeek[];
   setConfigWeeks: (weeks: ConfigWeek[]) => void;
   maxWeeklyScore: number;
-  setMaxWeeklyScore: (score: number) => void;
   totalAssessmentWeighting: number;
   setTotalAssessmentWeighting: (weight: number) => void;
   activeWorkshopId: string | null;
@@ -83,7 +82,6 @@ type PersistedState = Partial<{
   workshops: WorkshopRecord[];
   workshopStudents: Record<string, WorkshopStudent[]>;
   configWeeks: ConfigWeek[];
-  maxWeeklyScore: number;
   totalAssessmentWeighting: number;
   sessionMarks: SessionMarks;
   activeWorkshopId: string | null;
@@ -115,7 +113,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
     if (Array.isArray(saved.configWeeks) && saved.configWeeks.length === defaultConfigWeeks.length) {
       setConfigWeeks(saved.configWeeks);
     }
-    if (typeof saved.maxWeeklyScore === "number") setMaxWeeklyScore(saved.maxWeeklyScore);
     if (typeof saved.totalAssessmentWeighting === "number") {
       setTotalAssessmentWeighting(saved.totalAssessmentWeighting);
     }
@@ -186,7 +183,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
           workshops,
           workshopStudents,
           configWeeks,
-          maxWeeklyScore,
           totalAssessmentWeighting,
           sessionMarks,
           activeWorkshopId,
@@ -204,7 +200,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
     workshops,
     workshopStudents,
     configWeeks,
-    maxWeeklyScore,
     totalAssessmentWeighting,
     sessionMarks,
     activeWorkshopId,
@@ -372,7 +367,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         workshops, setWorkshops, createWorkshop, deleteWorkshop, updateWorkshopTutor, assignCurrentUserAsTutor,
         workshopStudents, upsertWorkshopStudentsFromCsv,
         configWeeks, setConfigWeeks,
-        maxWeeklyScore, setMaxWeeklyScore,
+        maxWeeklyScore,
         totalAssessmentWeighting, setTotalAssessmentWeighting,
         activeWorkshopId, setActiveWorkshopId,
         sessionMarks, setMark, clearWeekMarks, getWeekMarkedCount,

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,10 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
-  /* config options here */
   images: {
     unoptimized: true,
   },
+  devIndicators: false,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

- Removes the editable Max Weekly Score input from the Settings > Unit Configuration page
- Replaces it with a read-only display field locked to `3`, with a note: _"Fixed per MVP scope"_
- Removes the now-unused `setMaxWeeklyScore` call from the config page (the setter still exists in context for any future use)

## Motivation

Per team decision confirmed during the mid-semester check-in: the max score per participation week is fixed at 3 for the MVP. Allowing coordinators to change this value would break grade calculations and the scoring rubric, so the field is now locked in the UI.

## Test plan

- [x] Open Settings → Unit Configuration
- [x] Confirm Max Weekly Score shows `3` and the input is greyed out / not editable
- [x] Confirm Total Participation Points and Grade Value per Point still calculate correctly when participation weeks are toggled
- [x] Confirm no TypeScript errors (`npm run build`)